### PR TITLE
feat: 🎸 add product/name on payment confirmation page

### DIFF
--- a/app/Helpers/smartpay.php
+++ b/app/Helpers/smartpay.php
@@ -1026,3 +1026,26 @@ function smartpay_debug_log($message = '', $force = false)
 function smartpay_get_available_payment_gateways($availableGateways) {
     return apply_filters('smartpay_get_available_payment_gateways', $availableGateways);
 }
+
+// get the form or product title from payment id
+function smartpay_get_payment_product_or_form_name($payment_id): array {
+	$payment = PaymentModel::find($payment_id);
+	if ($payment->type == 'Product Purchase') {
+		$product = \SmartPay\Models\Product::find($payment->data['product_id']);
+		if ($product) {
+			$name = $product->title;
+			$prev_link = $product->extra['product_preview_page_permalink'];
+		}
+	} else {
+		$form = \SmartPay\Models\Form::find($payment->data['form_id']);
+		if ($form) {
+			$name = $form->title;
+			$prev_link = $form->extra['form_preview_page_permalink'];
+		}
+	}
+
+	return [
+		'name' => $name ?? 'No Name',
+		'preview'   =>$prev_link ?? '#'
+	];
+}

--- a/resources/views/shortcodes/payment_receipt.php
+++ b/resources/views/shortcodes/payment_receipt.php
@@ -10,6 +10,17 @@ if ($payment) : ?>
             <td><?php _e('Payment ID:', 'smartpay') ?></td>
             <td><?php echo esc_html($payment->id); ?></td>
         </tr>
+
+        <tr>
+            <td><?php _e( $payment->type == 'Product Purchase' ? 'Product Name' : 'Form Name:', 'smartpay') ?></td>
+            <td>
+                <a href="<?php echo smartpay_get_payment_product_or_form_name($payment->id)['preview'];?>" target="_blank">
+	                <?php echo esc_html(smartpay_get_payment_product_or_form_name($payment->id)['name']); ?>
+                </a>
+            </td>
+<!--            <td>--><?php //echo esc_html(smartpay_get_payment_product_or_form_name($payment->id)); ?><!--</td>-->
+        </tr>
+
         <tr>
             <td><?php _e('Name:', 'smartpay') ?></td>
             <td><?php echo esc_html($payment->customer->first_name . ' ' . $payment->customer->last_name); ?></td>


### PR DESCRIPTION
![Screenshot from 2022-05-18 09-51-43](https://user-images.githubusercontent.com/57439878/168953792-2e6ee276-7815-419a-953a-f116e67268ac.png)

[N. B] - From the Order Id Preview link,  customer can show the Product or Form name what they have paid.

Previous Image:
![Screenshot from 2022-05-18 09-51-22](https://user-images.githubusercontent.com/57439878/168953802-308ed987-1f20-45f5-8031-d8eb97be54fb.png)

Nifty Task Link - https://themexpert.nifty.pm/l/yZNveGqYVa4

Updated customer dashboard:
Remove 'Actions' tab from the page and added preview link on order ID
Also added order creation date if order was not completed yet.

![Screenshot from 2022-05-18 11-32-45](https://user-images.githubusercontent.com/57439878/168964473-795a3a36-8a3c-4e0f-a6f1-264113d5e651.png) 