### PR TITLE
fix: wrong version showing in WordPress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-smartpay",
-    "version": "2.7.10",
+    "version": "2.7.11",
     "description": "A simple plugin for receiving payment.",
     "repository": {
         "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Download Manager and Payment Form WordPress Plugin - WP SmartPay ===
 Contributors: themesgrove
 Tags: download manager, digital product, donation, ecommerce, stripe, paypal, paddle, document manager, file manager, download protection, recurring payment, donations, donation plugin, wordpress donation plugin, wp donation, fundraising, fundraiser, crowdfunding, wordpress donations, gutenberg, gutenberg donations, nonprofit, paypal donations, paypal donate, stripe donations, stripe donate, authorize.net, authorize.net donations, bkash, bkash payment,
-Requires at least: 4.9
+Requires at least: 6.0
 Tested up to: 6.6.7
 Requires PHP: 8.1
-Stable Tag: 2.7.10
+Stable Tag: 2.7.11
 License: GNU Version 2 or later
 
 The Simplest way to sell digital downloads and set up payment forms with Stripe, Paypal and Paddle. Accept donations, service payment and manage downloads with ease.
@@ -112,6 +112,9 @@ The easiest way to install WP SmartPay is to search for it via your site’s Das
 7. Seamless one click checkout
 
 == Changelog ==
+= [2.7.11] =
+* Fix - WordPress was showing wrong version.
+
 = [2.7.10] =
 * Fix - Errors due to return type declaration.
 * Fix - Error due to early triggering text domain.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: themesgrove
 Tags: download manager, digital product, donation, ecommerce, stripe, paypal, paddle, document manager, file manager, download protection, recurring payment, donations, donation plugin, wordpress donation plugin, wp donation, fundraising, fundraiser, crowdfunding, wordpress donations, gutenberg, gutenberg donations, nonprofit, paypal donations, paypal donate, stripe donations, stripe donate, authorize.net, authorize.net donations, bkash, bkash payment,
 Requires at least: 6.0
-Tested up to: 6.6.7
+Tested up to: 6.7
 Requires PHP: 8.1
 Stable Tag: 2.7.11
 License: GNU Version 2 or later

--- a/smartpay.php
+++ b/smartpay.php
@@ -1,11 +1,15 @@
 <?php
-
 /**
  * Plugin Name: SmartPay
  * Description: Simplest way to sell digital downloads and fundraise with WordPress. Easily connect Paddle, Stripe, Paypal to accept donations and manage downloads.
  * Plugin URI:  https://wpsmartpay.com/?utm_source=wp-plugins&utm_campaign=plugin-uri&utm_medium=wp-dash
  * Tags: download manager, digital product, donation, ecommerce, paddle, stripe, paypal, document manager, file manager, download protection, recurring payment, donations, donation plugin, wordpress donation plugin, wp donation, fundraising, fundraiser, crowdfunding, wordpress donations, gutenberg, gutenberg donations, nonprofit, paypal donations, paypal donate, stripe donations, stripe donate, authorize.net, authorize.net donations, bkash, bkash payment,
- * Version:     2.7.10
+ *
+ * Version: 2.7.11
+ * Requires PHP: 8.1
+ * Requires at least: 6.0
+ * Tested up to: 6.7
+ *
  * Author:      WPSmartPay
  * Author URI:  https://wpsmartpay.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash
  * Text Domain: smartpay
@@ -27,7 +31,7 @@
 
 defined('ABSPATH') || exit;
 
-define('SMARTPAY_VERSION', '2.7.10');
+define('SMARTPAY_VERSION', '2.7.11');
 define('SMARTPAY_PLUGIN_FILE', __FILE__);
 define('SMARTPAY_PLUGIN_ASSETS', plugins_url('public', __FILE__));
 define('SMARTPAY_STORE_URL', 'https://wpsmartpay.com/');


### PR DESCRIPTION
This pull request includes several updates to the WP SmartPay plugin, focusing on version updates and compatibility improvements. The most important changes include updating the version number and adjusting the minimum required WordPress and PHP versions.

Version and compatibility updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the plugin version from `2.7.10` to `2.7.11`.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L4-R7): Updated the stable tag to `2.7.11` and changed the minimum required WordPress version to `6.0`.
* [`smartpay.php`](diffhunk://#diff-aad82735cd81c59a30cae991a060e61ef57622d48785a7e0e3c72196eb4180cbL2-R12): Updated the plugin version to `2.7.11`, set the minimum required PHP version to `8.1`, and updated the minimum required WordPress version to `6.0`. [[1]](diffhunk://#diff-aad82735cd81c59a30cae991a060e61ef57622d48785a7e0e3c72196eb4180cbL2-R12) [[2]](diffhunk://#diff-aad82735cd81c59a30cae991a060e61ef57622d48785a7e0e3c72196eb4180cbL30-R34)

Changelog update:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R115-R117): Added a changelog entry for version `2.7.11` to indicate a fix for WordPress showing the wrong version.