### PR TITLE
feat: workflow manual trigger

### DIFF
--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to WordPress.org
 on:
+    # Manual workflow trigger
+    workflow_dispatch:
+    
     push:
         tags:
             - '*'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/wordpress-org-deploy.yml` file. The change adds a manual workflow trigger to the deployment workflow.

* [`.github/workflows/wordpress-org-deploy.yml`](diffhunk://#diff-b51acf0e800e16a31bd0475c46243bb7ab59f814a74ef89c89b7509a662f8de2R3-R5): Added `workflow_dispatch` to enable manual triggering of the deployment workflow.