### PR TITLE
fix: add instructions to enable gateways

### DIFF
--- a/app/Modules/Admin/Setting.php
+++ b/app/Modules/Admin/Setting.php
@@ -693,6 +693,8 @@ class Setting
                     $html .= '</div>';
                 }
             }
+        } else {
+            $html .= '<small class="form-text text-muted">' . __( 'Add more payment gateways from the Integrations panel.', 'smartpay' ) . '</small>';
         }
 
         $url   = esc_url('https://wpsmartpay.com');


### PR DESCRIPTION
This pull request includes a small change to the `app/Modules/Admin/Setting.php` file. The change adds a message to the `settings_gateways_callback` function to inform users that they can add more payment gateways from the Integrations panel.

Change to user messaging:

* [`app/Modules/Admin/Setting.php`](diffhunk://#diff-4427d398646d436f3f47ae7fd66cbe73f995ad27c5c74d3fdaaab8e29e5dd2a2R696-R697): Added a message to the `settings_gateways_callback` function to inform users about adding more payment gateways from the Integrations panel.