### PR TITLE
fix: text domain warning

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -24,7 +24,7 @@ Updater::boot();
 add_action('plugins_loaded', function () {
     require_once(ABSPATH . '/wp-admin/includes/plugin.php');
     if (defined('SMARTPAY_PRO_VERSION')) {
-        if (floatval(SMARTPAY_PRO_VERSION) < 2.6){
+        if (floatval(SMARTPAY_PRO_VERSION) < 2.6 && "##SMARTPAY_PRO_VERSION##" !== SMARTPAY_PRO_VERSION){
             add_action('admin_notices', 'smartpay_pro_deactivate_notice');
             deactivate_plugins(SMARTPAY_PRO_PLUGIN_FILE);
         }

--- a/smartpay.php
+++ b/smartpay.php
@@ -47,11 +47,14 @@ add_action('plugins_loaded', function () use ($app) {
     do_action('smartpay_loaded');
 
     // Run The Application
-    $app->boot();
+    // $app->boot();
 });
 
-add_action('init', function () {
+add_action('init', function () use ($app) {
     do_action('smartpay_init');
+
+    // Run The Application
+    $app->boot();
 
     // Load translations
     load_plugin_textdomain('smartpay', false, dirname(plugin_basename(__FILE__)) . '/resources/languages');


### PR DESCRIPTION
This pull request introduces changes to improve compatibility checks and refactor the initialization process for the SmartPay plugin. 

### Initialization Refactor:
* [`smartpay.php`](diffhunk://#diff-aad82735cd81c59a30cae991a060e61ef57622d48785a7e0e3c72196eb4180cbL50-R58): Moved the application boot (`$app->boot()`) from an earlier hook to the `init` action, ensuring it runs in the correct context. This change also ensures that translations are loaded after the application is initialized.