### PR TITLE
fix: sanitize input data

### DIFF
--- a/app/Modules/Payment/Payment.php
+++ b/app/Modules/Payment/Payment.php
@@ -239,16 +239,21 @@ class Payment
 
     private function _get_payment_customer($_data)
     {
-        $customer = Customer::where('email', $_data['smartpay_email'])->first();
+        // Sanitize Data.
+        $first_name = sanitize_text_field( $_data['smartpay_first_name'] ?? '' );
+        $last_name  = sanitize_text_field( $_data['smartpay_last_name'] ?? '' );
+        $email      = sanitize_email( sanitize_text_field( $_data['smartpay_email'] ?? '' ) );
+
+        $customer = Customer::where('email', $email)->first();
 
         if ($customer && $customer->id) {
             $customer_id = $customer->id;
         } else {
             $customer = new Customer();
             $customer->user_id      = is_user_logged_in() ? get_current_user_id() : 0;
-            $customer->first_name   = $_data['smartpay_first_name'];
-            $customer->last_name    = $_data['smartpay_last_name'];
-            $customer->email        = $_data['smartpay_email'];
+            $customer->first_name   = $first_name;
+            $customer->last_name    = $last_name;
+            $customer->email        = $email;
 
             $customer->save();
             $customer_id = $customer->id;
@@ -256,9 +261,9 @@ class Payment
 
         return [
             'customer_id' => $customer_id ?? 0,
-            'first_name'  => $_data['smartpay_first_name'] ?? '',
-            'last_name'   => $_data['smartpay_last_name'] ?? '',
-            'email'       => $_data['smartpay_email'] ?? '',
+            'first_name'  => $first_name,
+            'last_name'   => $last_name,
+            'email'       => $email,
         ];
     }
 


### PR DESCRIPTION
This pull request focuses on improving data sanitization and security by ensuring that user input is properly sanitized before being processed or stored. The changes primarily affect the handling of customer data in REST API endpoints and payment-related functionality.

### Input Sanitization Enhancements:

* `app/Http/Controllers/Rest/CustomerController.php`:
  - Added sanitization for `first_name`, `last_name`, and `email` fields in the `update` method using `sanitize_text_field` and `sanitize_email`. This ensures that user-provided data is cleaned before validation and storage.
  - Updated the `update` method to use sanitized variables when assigning values to the `Customer` model and updating WordPress user data.

* `app/Modules/Payment/Payment.php`:
  - Introduced sanitization for `smartpay_first_name`, `smartpay_last_name`, and `smartpay_email` fields in the `_get_payment_customer` method. This ensures that customer data is sanitized before being queried or stored in the database.