### PR TITLE
Fix/security issues 301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.vscode
 /node_modules
 /public/hot
 /public/storage

--- a/app/Helpers/integration.php
+++ b/app/Helpers/integration.php
@@ -54,5 +54,6 @@ function smartpay_integration_get_not_installed_message(string $type): void
             break;
     }
 
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
     echo apply_filters('smartpay_integration_get_not_installed_message', $message, $type);
 }

--- a/app/Http/Controllers/Rest/Admin/ProductController.php
+++ b/app/Http/Controllers/Rest/Admin/ProductController.php
@@ -48,6 +48,7 @@ class ProductController extends RestController
     public function store(WP_REST_Request $request): WP_REST_Response
     {
         global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $wpdb->query('START TRANSACTION');
 
         try {
@@ -70,6 +71,7 @@ class ProductController extends RestController
                     $this->createVariation($variationData, $product->id);
                 });
 
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
                 $wpdb->query('COMMIT');
 
                 // get the currently stored product
@@ -77,11 +79,13 @@ class ProductController extends RestController
 
                 return new WP_REST_Response(['product' => $product, 'message' => __('Product created', 'smartpay')]);
             }else{
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
                 $wpdb->query('ROLLBACK');
                 error_log('Failed to create product.');
                 return new WP_REST_Response(['message' => __('Failed to create product.', 'smartpay')], 500);
             }
         } catch (\Exception $e) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query('ROLLBACK');
             error_log($e->getMessage());
             return new WP_REST_Response(['message' => __($e->getMessage(), 'smartpay')], 500);
@@ -108,6 +112,7 @@ class ProductController extends RestController
     public function update(WP_REST_Request $request): WP_REST_Response
     {
         global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $wpdb->query('START TRANSACTION');
 
         try {
@@ -148,11 +153,13 @@ class ProductController extends RestController
                 $variation->save();
             });
 
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query('COMMIT');
             //            $product->refresh();
             $product->load('variations');
             return new WP_REST_Response(['product' => $product, 'message' => __('Product updated', 'smartpay')]);
         } catch (\Exception $e) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query('ROLLBACK');
             error_log($e->getMessage());
             return new WP_REST_Response($e->getMessage(), 500);
@@ -168,6 +175,7 @@ class ProductController extends RestController
     public function destroy(WP_REST_Request $request): WP_REST_Response
     {
         global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $wpdb->query('START TRANSACTION');
 
         try {
@@ -182,9 +190,11 @@ class ProductController extends RestController
             }
 
             $product->delete();
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query('COMMIT');
             return new WP_REST_Response(['message' => __('Product deleted', 'smartpay')], 200);
         } catch (\Exception $e) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query('ROLLBACK');
             error_log($e->getMessage());
             return new WP_REST_Response($e->getMessage(), 500);

--- a/app/Http/Controllers/Rest/CustomerController.php
+++ b/app/Http/Controllers/Rest/CustomerController.php
@@ -72,6 +72,7 @@ class CustomerController extends RestController
         };
 
         global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $wpdb->query('START TRANSACTION');
 
         $customer->first_name = $firstName;
@@ -87,10 +88,12 @@ class CustomerController extends RestController
         ]);
 
         if (is_wp_error($userdata)) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query('ROLLBACK');
             return new WP_REST_Response(['message' => __('Customer info not updated', 'smartpay')], 404);
         }
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $wpdb->query('COMMIT');
         return new WP_REST_Response(['customer' => $customer, 'message' => __('Customer updated', 'smartpay')]);
     }

--- a/app/Modules/Admin/Admin.php
+++ b/app/Modules/Admin/Admin.php
@@ -32,6 +32,7 @@ class Admin
             'manage_options',
             'smartpay',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('admin');
             },
             smartpay_svg_icon(),
@@ -45,6 +46,7 @@ class Admin
             'manage_options',
             'smartpay',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('admin');
             }
         );
@@ -56,6 +58,7 @@ class Admin
             'manage_options',
             'smartpay#/products',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('admin');
             }
         );
@@ -67,6 +70,7 @@ class Admin
             'manage_options',
             'smartpay-form',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('form-builder');
             }
         );
@@ -78,6 +82,7 @@ class Admin
             'manage_options',
             'smartpay#/customers',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('admin');
             }
         );
@@ -89,6 +94,7 @@ class Admin
             'manage_options',
             'smartpay#/coupons',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('admin');
             }
         );
@@ -100,6 +106,7 @@ class Admin
             'manage_options',
             'smartpay#/payments',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('admin');
             }
         );
@@ -111,6 +118,7 @@ class Admin
             'manage_options',
             'smartpay-setting',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('settings');
             }
         );
@@ -122,6 +130,7 @@ class Admin
             'manage_options',
             'smartpay-integrations',
             function () {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo smartpay_view('integrations');
             }
         );
@@ -289,7 +298,7 @@ class Admin
                     <div class="introduction-video">
                         <iframe width="560" height="315" src="https://www.youtube.com/embed/PdqA7XNH60Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-                        <!--                        <p>--><?php //_e('Spend 3 minutes ( literally 3 minutes ) watching the video to get an overview how it works.'); 
+                        <!--                        <p>--><?php //_e('Spend 3 minutes ( literally 3 minutes ) watching the video to get an overview how it works.');
                                                             ?>
                         <!--</p>-->
                     </div>

--- a/app/Modules/Admin/Admin.php
+++ b/app/Modules/Admin/Admin.php
@@ -219,7 +219,7 @@ class Admin
         }
 
         // Global
-        wp_enqueue_script('smartpay-editor-blocks', SMARTPAY_PLUGIN_ASSETS . '/blocks/index.js', ['wp-element', 'wp-plugins', 'wp-blocks', 'wp-block-editor', 'wp-data']);
+        wp_enqueue_script('smartpay-editor-blocks', SMARTPAY_PLUGIN_ASSETS . '/blocks/index.js', ['wp-element', 'wp-plugins', 'wp-blocks', 'wp-block-editor', 'wp-data'], SMARTPAY_VERSION, true);
 
         // Product
         register_block_type('smartpay/product', array(

--- a/app/Modules/Admin/Admin.php
+++ b/app/Modules/Admin/Admin.php
@@ -279,12 +279,12 @@ class Admin
         <div class="wpsmartpay-welcome">
             <div class="container">
                 <div class="introduction-image">
-                    <img src="<?php echo SMARTPAY_PLUGIN_ASSETS . '/img/logo.png' ?>" alt="<?php esc_attr_e('SmartPay Logo', 'smartpay'); ?>">
+                    <img src="<?php echo esc_url(SMARTPAY_PLUGIN_ASSETS . '/img/logo.png') ?>" alt="<?php esc_attr_e('SmartPay Logo', 'smartpay'); ?>">
                 </div>
                 <div class="introduction">
                     <div class="introduction-text">
-                        <h2><?php _e('Welcome Aboard'); ?></h2>
-                        <p><?php _e('Congratulations you are just few minutes away form displaying your digital products to selling it and receiving payments, all-in-one Simplest solution.'); ?></p>
+                        <h2><?php esc_html_e('Welcome Aboard'); ?></h2>
+                        <p><?php esc_html_e('Congratulations you are just few minutes away form displaying your digital products to selling it and receiving payments, all-in-one Simplest solution.'); ?></p>
                     </div>
                     <div class="introduction-video">
                         <iframe width="560" height="315" src="https://www.youtube.com/embed/PdqA7XNH60Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -296,12 +296,12 @@ class Admin
                 </div>
 
                 <div class="subscription-form">
-                    <h3><?php _e('Wanna get some discount?', 'smartpay'); ?></h3>
-                    <p><?php _e('No Worries!! We got you!! give us your email we will send you the discount code.', 'smartpay'); ?></p>
+                    <h3><?php esc_html_e('Wanna get some discount?', 'smartpay'); ?></h3>
+                    <p><?php esc_html_e('No Worries!! We got you!! give us your email we will send you the discount code.', 'smartpay'); ?></p>
                     <form>
                         <div class="inline-input-wrapper">
                             <input type="email" placeholder="<?php esc_attr_e('Email Address', 'smartpay'); ?>" value="<?php echo esc_attr($user->user_email); ?>" />
-                            <button type="submit" class="button button-primary"><?php _e('Get Discount'); ?></button>
+                            <button type="submit" class="button button-primary"><?php esc_html_e('Get Discount'); ?></button>
                         </div>
                     </form>
                 </div>
@@ -309,10 +309,10 @@ class Admin
                 <div class="create-form-section">
                     <div class="button-wrap">
                         <div class="left-side">
-                            <a class="dashboard-button button" href="<?php echo esc_url(admin_url('admin.php?page="smartpay-form#/create"')); ?>"><?php _e('Create Your First Form', 'smartpay'); ?></a>
+                            <a class="dashboard-button button" href="<?php echo esc_url(admin_url('admin.php?page="smartpay-form#/create"')); ?>"><?php esc_html_e('Create Your First Form', 'smartpay'); ?></a>
                         </div>
                         <div class="right-side">
-                            <a class="dashboard-button button" href="<?php echo esc_url(admin_url('admin.php?page="smartpay#/products/create"')); ?>"><?php _e('Create Your First Product', 'smartpay'); ?></a>
+                            <a class="dashboard-button button" href="<?php echo esc_url(admin_url('admin.php?page="smartpay#/products/create"')); ?>"><?php esc_html_e('Create Your First Product', 'smartpay'); ?></a>
                         </div>
                     </div>
                 </div>
@@ -377,7 +377,7 @@ class Admin
             <div class="notice notice-warning is-dismissible smartpay-notice-wrapper">
                 <img src="<?php echo esc_url(SMARTPAY_PLUGIN_ASSETS . '/img/favicon.png'); ?>" alt="<?php esc_attr_e('Logo', 'smartpay') ?>">
                 <div class="smartpay-notice-content">
-                    <h4><?php _e('Wanna get some discount for WP SmartPay Pro? No Worries!! We got you!! give us your email we will send you the discount code.') ?></h4>
+                    <h4><?php esc_html_e('Wanna get some discount for WP SmartPay Pro? No Worries!! We got you!! give us your email we will send you the discount code.') ?></h4>
                     <form style="display:flex">
                         <div class="smartpay-notice-input-wrapper">
                             <input type="text" value="<?php echo esc_attr($user->first_name); ?>" placeholder="<?php esc_attr_e('Name', 'smartpay'); ?>" />
@@ -385,7 +385,7 @@ class Admin
                         <div class="smartpay-notice-input-wrapper">
                             <input type="email" value="<?php echo esc_attr($user->user_email); ?>" required placeholder="<?php esc_attr_e('Email Address', 'smartpay'); ?>" />
                         </div>
-                        <button type="submit" class="button button-primary subscribe-button"><?php _e('Get Discount'); ?></button>
+                        <button type="submit" class="button button-primary subscribe-button"><?php esc_html_e('Get Discount'); ?></button>
                     </form>
                 </div>
             </div>

--- a/app/Modules/Admin/Setting.php
+++ b/app/Modules/Admin/Setting.php
@@ -718,10 +718,10 @@ class Setting
 
     public function settings_missing_callback($args)
     {
-        printf(
+        wp_kses_post(sprintf(
             __('The callback function used for the %s setting is missing.', 'smartpay'),
             '<strong>' . $args['id'] . '</strong>'
-        );
+        ));
     }
 
     public function settings_page_select_callback($args)

--- a/app/Modules/Admin/Setting.php
+++ b/app/Modules/Admin/Setting.php
@@ -487,6 +487,7 @@ class Setting
         }
         $args['options'] = $currencies;
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $this->settings_select_callback($args);
     }
 
@@ -551,6 +552,7 @@ class Setting
         $html .= '</select>';
         $html .= '<small class="form-text text-muted" for="smartpay_settings[' . smartpay_sanitize_key($args['id']) . ']"> ' . wp_kses_post($args['desc']) . '</small>';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $html;
     }
 
@@ -573,6 +575,7 @@ class Setting
         $html .= '<label for="smartpay_settings[' . smartpay_sanitize_key($args['id']) . ']"></label>';
         $html    .= '<small class="form-text text-muted">' . wp_kses_post($args['desc']) . '</small>';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $html;
     }
 
@@ -603,6 +606,8 @@ class Setting
             }
         }
         $html         .= '<small class="form-text text-muted">' . wp_kses_post($args['desc']) . '</small>';
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo apply_filters('smartpay_after_setting_output', $html, $args);
     }
 
@@ -627,6 +632,7 @@ class Setting
         $html    .= '</div>';
         $html         .= '<small class="form-text text-muted">' . wp_kses_post($args['desc']) . '</small>';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo apply_filters('smartpay_after_setting_output', $html, $args);
     }
 
@@ -700,6 +706,7 @@ class Setting
         $url   = esc_url('https://wpsmartpay.com');
         $html .= '<small class="form-text text-muted">' . sprintf(__('Don\'t see what you need? More Payment Gateway options are available <a href="%s">here</a>.', 'smartpay'), $url) . '</small>';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo  $html;
     }
 
@@ -741,6 +748,7 @@ class Setting
             'option_none_value'     => null, // string
         );
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         wp_dropdown_pages($args);
         // FIXME:: Show label
     }
@@ -774,18 +782,7 @@ class Setting
         $html    .= '<small class="form-text text-muted">' . wp_kses_post($args['desc']) . '</small>';
 
         // $html    .= '<label for="smartpay_settings[' . smartpay_sanitize_key($args['id']) . ']"> '  . wp_kses_post($args['desc']) . '</label>';
-        echo $html;
-    }
-
-    public function settings_custom_content_callback($args)
-    {
-        echo $args['content'] ?? '';
-    }
-
-    public function  settings_descriptive_text_callback($args)
-    {
-        $html = wp_kses_post($args['desc']);
-
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $html;
     }
 
@@ -834,6 +831,7 @@ class Setting
         $html = '<textarea class="' . $class . ' large-text" cols="' . esc_attr($cols) . '" rows="' . esc_attr($rows) . '" style="'.$style.'" id="smartpay_settings[' . smartpay_sanitize_key($args['id']) . ']" name="smartpay_settings[' . smartpay_sanitize_key($args['id']) . ']">' . esc_textarea(stripslashes($value)) . '</textarea>';
         $html .= '<label for="smartpay_settings[' . smartpay_sanitize_key($args['id']) . ']"> '  . wp_kses_post($args['desc']) . '</label>';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $html;
     }
 
@@ -962,6 +960,7 @@ class Setting
 
         wp_nonce_field(smartpay_sanitize_key($args['id']) . '-nonce', smartpay_sanitize_key($args['id']) . '-nonce');
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $html;
     }
 }

--- a/app/Modules/Coupon/Coupon.php
+++ b/app/Modules/Coupon/Coupon.php
@@ -105,15 +105,15 @@ class Coupon
         ?>
         <div class="smartpay-coupon-form-toggle">
             <div class="coupon-info mb-4 p-4 bg-light">
-                <?php _e('Have a coupon?', 'smartpay'); ?>
-                <a href="#" class="smartpayshowcoupon"><?php _e('Click here to enter your code', 'smartpay'); ?></a>
+                <?php esc_html_e('Have a coupon?', 'smartpay'); ?>
+                <a href="#" class="smartpayshowcoupon"><?php esc_html_e('Click here to enter your code', 'smartpay'); ?></a>
             </div>
         </div>
         <form class="smartpay-coupon-form px-4 py-5 bg-light d-none position-relative">
             <span class="d-inline-block smartpay-coupon-form-close position-absolute bg-danger text-white p-2">X</span>
             <div class="d-flex">
-                <input type="text" name="coupon_code" class="m-0" placeholder="<?php _e('Coupon code', 'smartpay'); ?>" id=" coupon_code" style="flex: 1;" />
-                <button class="rounded" type="submit" name="submitcoupon"><?php _e('Apply coupon', 'smartpay'); ?></button>
+                <input type="text" name="coupon_code" class="m-0" placeholder="<?php esc_attr_e('Coupon code', 'smartpay'); ?>" id=" coupon_code" style="flex: 1;" />
+                <button class="rounded" type="submit" name="submitcoupon"><?php esc_html_e('Apply coupon', 'smartpay'); ?></button>
             </div>
         </form>
         <?php
@@ -188,7 +188,7 @@ class Coupon
         <div class="discount-amounts-container mb-3 d-none">
             <div class="py-2">
                 <p class="d-flex justify-content-between m-0">
-                    <span class="font-weight-bold"><?php _e('Subtotal', 'smartpay'); ?></span>
+                    <span class="font-weight-bold"><?php esc_html_e('Subtotal', 'smartpay'); ?></span>
                     <span class="subtotal-amount-value"></span>
                 </p>
             </div>
@@ -204,7 +204,7 @@ class Coupon
 
             <div class="py-2">
                 <p class="d-flex justify-content-between m-0">
-                    <span class="font-weight-bold"><?php _e('Total Amount', 'smartpay'); ?></span>
+                    <span class="font-weight-bold"><?php esc_html_e('Total Amount', 'smartpay'); ?></span>
                     <span class="total-amount-value"></span>
                 </p>
             </div>
@@ -223,14 +223,14 @@ class Coupon
         ?>
         <div class="smartpay-product-coupon-form-toggle">
             <div class="coupon-info mb-4 p-4 bg-light">
-                <?php _e('Have a coupon?', 'smartpay'); ?>
-                <a href="#" class="smartpayshowcoupon"><?php _e('Click here to enter your code', 'smartpay'); ?></a>
+                <?php esc_html_e('Have a coupon?', 'smartpay'); ?>
+                <a href="#" class="smartpayshowcoupon"><?php esc_html_e('Click here to enter your code', 'smartpay'); ?></a>
             </div>
         </div>
         <form class="smartpay-product-coupon-form p-4 bg-light d-none">
             <div class="d-flex">
-                <input type="text" name="coupon_code" class="m-0" placeholder="<?php _e('Coupon code', 'smartpay'); ?>" id=" coupon_code" style="flex: 1;" />
-                <button class="rounded" type="submit" name="submitcoupon"><?php _e('Apply coupon', 'smartpay'); ?></button>
+                <input type="text" name="coupon_code" class="m-0" placeholder="<?php esc_attr_e('Coupon code', 'smartpay'); ?>" id=" coupon_code" style="flex: 1;" />
+                <button class="rounded" type="submit" name="submitcoupon"><?php esc_html_e('Apply coupon', 'smartpay'); ?></button>
             </div>
         </form>
     <?php }

--- a/app/Modules/Form/Form.php
+++ b/app/Modules/Form/Form.php
@@ -102,7 +102,8 @@ class Form
             'smartpay-form',
             SMARTPAY_PLUGIN_ASSETS . '/form-builder/index.js',
             ['lodash', 'wp-block-editor', 'wp-block-library', 'wp-blocks', 'wp-components', 'wp-data', 'wp-dom-ready', 'wp-editor', 'wp-element', 'wp-format-library', 'wp-i18n', 'wp-media-utils', 'wp-plugins', 'wp-polyfill', 'wp-primitives'],
-            SMARTPAY_VERSION
+            SMARTPAY_VERSION,
+	        false
         );
 
         wp_localize_script(

--- a/app/Modules/Frontend/Common.php
+++ b/app/Modules/Frontend/Common.php
@@ -25,7 +25,7 @@ class Common
         wp_register_style('smartpay-app', SMARTPAY_PLUGIN_ASSETS . '/css/app.css', '', SMARTPAY_VERSION);
         wp_enqueue_style('smartpay-app');
 
-        wp_register_script('smartpay-bootstrap', SMARTPAY_PLUGIN_ASSETS . '/js/bootstrap.js', ['jquery'], SMARTPAY_VERSION);
+        wp_register_script('smartpay-bootstrap', SMARTPAY_PLUGIN_ASSETS . '/js/bootstrap.js', ['jquery'], SMARTPAY_VERSION, true);
         wp_enqueue_script('smartpay-bootstrap');
         wp_register_script('smartpay-app', SMARTPAY_PLUGIN_ASSETS . '/js/app.js', ['jquery'], SMARTPAY_VERSION, true);
         wp_enqueue_script('smartpay-app');

--- a/app/Modules/Frontend/Utilities/Downloader.php
+++ b/app/Modules/Frontend/Utilities/Downloader.php
@@ -1298,6 +1298,7 @@ class Downloader
 
         while (!@feof($handle)) {
             $buffer = @fread($handle, $chunksize);
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
             echo $buffer;
             ob_flush();
 

--- a/app/Modules/Frontend/Utilities/Downloader.php
+++ b/app/Modules/Frontend/Utilities/Downloader.php
@@ -39,7 +39,7 @@ class Downloader
         $validation = $this->checkDownloadUrl();
 
         if (!$validation['is_valid']) {
-            wp_die(__('Sorry! Maybe your token is invalid or you don\'t have the access.', 'smartpay'), __('Error', 'smartpay'), array('response' => 403));
+            wp_die(esc_html__('Sorry! Maybe your token is invalid or you don\'t have the access.', 'smartpay'), esc_html__('Error', 'smartpay'), array('response' => 403));
         }
 
         extract($validation);
@@ -48,19 +48,19 @@ class Downloader
 
         // FIXME
         if (!$payment_id || !$payment || 'Completed' !== $payment->status) {
-            wp_die(__('Sorry! Payment invalid or not completed yet.', 'smartpay'), __('Error', 'smartpay'), array('response' => 403));
+            wp_die(esc_html__('Sorry! Payment invalid or not completed yet.', 'smartpay'), esc_html__('Error', 'smartpay'), array('response' => 403));
         }
 
         $product = Product::find($product_id);
 
         if (!$product_id || !$product || !$product->isPurchasable()) {
-            wp_die(__('Sorry! This product is invalid or don\'t have right permission.', 'smartpay'), __('Error', 'smartpay'), array('response' => 403));
+            wp_die(esc_html__('Sorry! This product is invalid or don\'t have right permission.', 'smartpay'), esc_html__('Error', 'smartpay'), array('response' => 403));
         }
 
         $fileIndex = array_search($file_id, array_column($product->files, 'id'));
 
         if (0 > $fileIndex) {
-            wp_die(__('Sorry! This file doesn\'t exist or don\'t have right permission.', 'smartpay'), __('Error', 'smartpay'), array('response' => 403));
+            wp_die(esc_html__('Sorry! This file doesn\'t exist or don\'t have right permission.', 'smartpay'), esc_html__('Error', 'smartpay'), array('response' => 403));
         }
 
         $requestedFile  = $product->files[$fileIndex];
@@ -88,7 +88,7 @@ class Downloader
 
         $supportedStreams = stream_get_wrappers();
         if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' && isset($fileDetails['scheme']) && !in_array($fileDetails['scheme'], $supportedStreams)) {
-            wp_die(__('Error downloading file. Please contact support.', 'smartpay'), __('File download error', 'smartpay'), 501);
+            wp_die(esc_html__('Error downloading file. Please contact support.', 'smartpay'), esc_html__('File download error', 'smartpay'), 501);
         }
 
         if ((!isset($fileDetails['scheme']) || !in_array($fileDetails['scheme'], $schemes)) && isset($fileDetails['path']) && file_exists($requestedFileUrl)) {
@@ -109,7 +109,7 @@ class Downloader
 
         // If we're using an attachment ID to get the file, even by path, we can ignore this check.
         if (false === $isAttachmentFile || !$this->isLocalFileLocationAllowed($fileDetails, $schemes, $requestedFileUrl)) {
-            wp_die(__('Sorry, this file could not be downloaded.', 'smartpay'), __('Error Downloading File', 'smartpay'), 403);
+            wp_die(esc_html__('Sorry, this file could not be downloaded.', 'smartpay'), esc_html__('Error Downloading File', 'smartpay'), 403);
         }
 
         // Write session data and end session
@@ -1490,7 +1490,7 @@ class Downloader
         wp_parse_str($parts['query'], $query_args);
 
         if (isset($query_args['ttl']) && current_time('timestamp') > $query_args['ttl']) {
-            wp_die(__('Sorry but your download link has expired.', 'smartpay'), __('Error', 'smartpay'), array('response' => 403));
+            wp_die(esc_html__('Sorry but your download link has expired.', 'smartpay'), esc_html__('Error', 'smartpay'), array('response' => 403));
         }
 
         if (!isset($query_args['token']) || !hash_equals($query_args['token'], $this->generateToken($url))) return false;

--- a/app/Modules/Gateway/Gateways/ManualPurchase/FreePurchase.php
+++ b/app/Modules/Gateway/Gateways/ManualPurchase/FreePurchase.php
@@ -87,6 +87,8 @@ final class FreePurchase extends PaymentGateway
 //                $content .= 'window.location.replace("'.$return_url.'");';
                 $content .= 'window.location.href = "'.$return_url.'";';
                 $content .= '</script>';
+
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
                 echo $content;
             } else {
                 smartpay_debug_log(__('SmartPay-FreePurchase: Sale price could not matched', 'smartpay'));

--- a/app/Modules/Gateway/Gateways/PaypalStandard.php
+++ b/app/Modules/Gateway/Gateways/PaypalStandard.php
@@ -156,6 +156,7 @@ class PaypalStandard extends PaymentGateway
         $content = '<p class="text-center">Redirecting to PayPal...</p>';
         $content .= '<script>window.location.replace("' . $paypal_redirect . '");</script>';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $content;
         return;
     }

--- a/app/Modules/Gateway/Gateways/PaypalStandard.php
+++ b/app/Modules/Gateway/Gateways/PaypalStandard.php
@@ -40,12 +40,12 @@ class PaypalStandard extends PaymentGateway
 
         if (empty($paypal_email)) {
             add_action('admin_notices', function () {
-                echo __(sprintf(
+                echo wp_kses_post( __(sprintf(
                     '<div class="error">
                         <p><strong>Paypal credentials was not set yet!</strong> To get the Paypal service on smartpay, you must add your paypal business email.  <a href="%s"> Input your paypal credentials</a></p>
                     </div>',
                     admin_url('admin.php?page=smartpay-setting&tab=gateways&section=paypal')
-                ), 'smartpay-pro');
+                ), 'smartpay-pro'));
             });
         }
     }
@@ -80,7 +80,7 @@ class PaypalStandard extends PaymentGateway
 				'wp-smartpay-edd' );
 			echo '<div class="smartpay">';
 			echo '<div class="receipt-alert receipt-alert-success">';
-			echo '<p>' . $message . '</p>';
+			echo '<p>' . wp_kses_post($message) . '</p>';
 			echo '<a class="receipt-alert-close">&times;</a>';
 			echo '</div>';
 			echo '</div>';
@@ -266,7 +266,7 @@ class PaypalStandard extends PaymentGateway
 
             // If payment not found
             if (!$payment) {
-                echo __(sprintf(
+                echo esc_html__(sprintf(
                     'SmartPay-Paypal: Webhook requested; Smartpay payment not found for #%s.',
                     $payment_id
                 ), 'smartpay');
@@ -422,7 +422,7 @@ class PaypalStandard extends PaymentGateway
 
     public function unsupported_currency_notice()
     {
-        echo __('<div class="error"><p>Unsupported currency! Your currency <code>' . strtoupper(smartpay_get_currency()) . '</code> does not supported by PayPal. Please change your currency from <a href="' . get_admin_url() . 'admin.php?page=smartpay-setting&tab=general">currency setting</a>.</p></div>', 'smartpay');
+        echo wp_kses_post(__('<div class="error"><p>Unsupported currency! Your currency <code>' . strtoupper(smartpay_get_currency()) . '</code> does not supported by PayPal. Please change your currency from <a href="' . get_admin_url() . 'admin.php?page=smartpay-setting&tab=general">currency setting</a>.</p></div>', 'smartpay'));
     }
 
     function get_paypal_redirect_url($ssl_check = false, $ipn = false)

--- a/app/Modules/Shortcode/Shortcode.php
+++ b/app/Modules/Shortcode/Shortcode.php
@@ -57,6 +57,7 @@ class Shortcode
         try {
             ob_start();
 
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
             echo smartpay_view('shortcodes.form', ['form' => $form, 'behavior' => $behavior, 'label' => $label]);
 
             return ob_get_clean();
@@ -92,7 +93,7 @@ class Shortcode
 
         try {
             ob_start();
-
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
             echo smartpay_view('shortcodes.product', ['product' => $product, 'behavior' => $behavior, 'label' => $label]);
 
             return ob_get_clean();
@@ -128,6 +129,7 @@ class Shortcode
 
         try {
             ob_start();
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
             echo smartpay_view('shortcodes.payment_receipt', ['payment' => $payment]);
 
             return ob_get_clean();
@@ -159,7 +161,7 @@ class Shortcode
         }
 
         ob_start();
-
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo smartpay_view('shortcodes.customer_dashboard', ['customer' => $customer]);
 
         return ob_get_clean();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -32,7 +32,17 @@ add_action('plugins_loaded', function () {
 }, 20);
 
 function smartpay_pro_deactivate_notice(){
-    echo __('<div class="error notice-warning"><p><code>WP SmartPay Pro '.SMARTPAY_PRO_VERSION. '</code> is not compatible with <code>WP SmartPay version 2.6.0</code> or higher. Please update the <code>WP SmartPay Pro</code> or downgrade the <code>WP SmartPay bellow 2.6.0</code>.</p></div>', 'smartpay');
+	echo '<div class="error notice-warning"><p>'
+	     . '<code>WP SmartPay Pro ' . esc_html( SMARTPAY_PRO_VERSION ) . '</code> '
+	     . esc_html__( ' is not compatible with ', 'smartpay' ) . ' '
+	     . '<code> WP SmartPay version 2.6.0 </code> '
+	     . esc_html__( ' or higher. Please update ', 'smartpay' ) . ' '
+	     . '<code> WP SmartPay Pro </code> '
+	     . esc_html__( ' or downgrade ', 'smartpay' ) . ' '
+	     . '<code> WP SmartPay </code>.'
+	     . esc_html__( ' below ', 'smartpay' ) . ' '
+	     . '<code> 2.6.0 </code>.'
+	     . '</p></div>';
 }
 
 return $app;

--- a/database/migrations/add_settings_column_on_products_table.php
+++ b/database/migrations/add_settings_column_on_products_table.php
@@ -19,17 +19,19 @@ class AddSettingsColumnOnProductTable
         $dbName = $wpdb->dbname;
 
         // check the settings column exist on products table
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $row = $wpdb->get_results("
-            SELECT COLUMN_NAME 
-            FROM INFORMATION_SCHEMA.COLUMNS 
-            WHERE TABLE_SCHEMA = '$dbName' AND 
-            TABLE_NAME = '$table' AND 
+            SELECT COLUMN_NAME
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = '$dbName' AND
+            TABLE_NAME = '$table' AND
             COLUMN_NAME = 'settings'
         ");
 
         // if no row found then create a new column on the products table
         // after the status table
         if (empty($row)) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
             $wpdb->query("ALTER TABLE $table ADD settings LONGTEXT DEFAULT NULL AFTER status");
         }
     }

--- a/database/migrations/add_uuid_column_on_payments_table.php
+++ b/database/migrations/add_uuid_column_on_payments_table.php
@@ -18,18 +18,20 @@ class AddUuidColumnOnPaymentTable
         $table = $wpdb->prefix . 'smartpay_payments';
         $dbName = $wpdb->dbname;
 
-        // check the settings column exist on products table
+        // check the uuid column exist on payments table
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $row = $wpdb->get_results("
-            SELECT COLUMN_NAME 
-            FROM INFORMATION_SCHEMA.COLUMNS 
-            WHERE TABLE_SCHEMA = '$dbName' AND 
-            TABLE_NAME = '$table' AND 
+            SELECT COLUMN_NAME
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = '$dbName' AND
+            TABLE_NAME = '$table' AND
             COLUMN_NAME = 'uuid'
         ");
 
         // if found, then it is in the payments table
 	    // if not, then add an uuid column after id
         if (empty($row)) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
             $wpdb->query("ALTER TABLE $table ADD uuid VARCHAR(255) DEFAULT NULL AFTER id");
         }
     }

--- a/database/migrations/create_coupons_table.php
+++ b/database/migrations/create_coupons_table.php
@@ -14,7 +14,11 @@ class CreateSmartpayCouponsTable
 
         $charsetCollate = $wpdb->get_charset_collate();
 
+		// coupons Table Creation, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         if ($wpdb->get_var("SHOW TABLES LIKE '$table'") != $table) {
+			// Schema creation with dbDelta() on plugin activation.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
             $sql = "CREATE TABLE $table (
                 `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 `title` VARCHAR(255) NOT NULL,

--- a/database/migrations/create_customers_table.php
+++ b/database/migrations/create_customers_table.php
@@ -10,7 +10,11 @@ class CreateSmartpayCustomersTable
 
         $charsetCollate = $wpdb->get_charset_collate();
 
+		// // customers Table Creation, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         if ($wpdb->get_var("SHOW TABLES LIKE '$table'") != $table) {
+			// Schema creation with dbDelta() on plugin activation.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
             $sql = "CREATE TABLE $table (
                 `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 `user_id` BIGINT UNSIGNED DEFAULT NULL,

--- a/database/migrations/create_forms_table.php
+++ b/database/migrations/create_forms_table.php
@@ -14,7 +14,11 @@ class CreateSmartpayFormsTable
 
         $charsetCollate = $wpdb->get_charset_collate();
 
+		// forms Table Creation, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         if ($wpdb->get_var("SHOW TABLES LIKE '$table'") != $table) {
+			// Schema creation with dbDelta() on plugin activation.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
             $sql = "CREATE TABLE $table (
                 `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 `title` VARCHAR(255) NOT NULL,

--- a/database/migrations/create_payments_table.php
+++ b/database/migrations/create_payments_table.php
@@ -15,7 +15,11 @@ class CreateSmartpayPaymentsTable
 
         $charsetCollate = $wpdb->get_charset_collate();
 
+		// payments Table Creation, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         if ($wpdb->get_var("SHOW TABLES LIKE '$table'") != $table) {
+			// Schema creation with dbDelta() on plugin activation.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
             $sql = "CREATE TABLE $table (
                 `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 `type` VARCHAR(25) DEFAULT '$defaultType',

--- a/database/migrations/create_products_table.php
+++ b/database/migrations/create_products_table.php
@@ -14,7 +14,11 @@ class CreateSmartpayProductsTable
 
         $charsetCollate = $wpdb->get_charset_collate();
 
+		// // products Table Creation, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         if ($wpdb->get_var("SHOW TABLES LIKE '$table'") != $table) {
+			// Schema creation with dbDelta() on plugin activation.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
             $sql = "CREATE TABLE $table (
                 `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 `title` VARCHAR(255) NOT NULL,

--- a/framework/Container/BoundMethod.php
+++ b/framework/Container/BoundMethod.php
@@ -182,7 +182,7 @@ class BoundMethod
         } elseif (!$parameter->isOptional() && !array_key_exists($paramName, $parameters)) {
             $message = "Unable to resolve dependency [{$parameter}] in class {$parameter->getDeclaringClass()->getName()}";
 
-            throw new BindingResolutionException($message);
+            throw new BindingResolutionException(esc_html($message));
         }
     }
 

--- a/framework/Container/Container.php
+++ b/framework/Container/Container.php
@@ -511,7 +511,9 @@ class Container implements ArrayAccess, ContainerContract
     public function alias($abstract, $alias) : void
     {
         if ($alias === $abstract) {
-            throw new LogicException("[{$abstract}] is aliased to itself.");
+            throw new LogicException(
+				sprintf("[%s] is aliased to itself.", esc_html($abstract))
+            );
         }
 
         $this->aliases[$alias] = $abstract;
@@ -661,7 +663,7 @@ class Container implements ArrayAccess, ContainerContract
                 throw $e;
             }
 
-            throw new EntryNotFoundException($id, $e->getCode(), $e);
+            throw new EntryNotFoundException(esc_html($id), (int) $e->getCode(), esc_html($e));
         }
     }
 
@@ -823,7 +825,7 @@ class Container implements ArrayAccess, ContainerContract
         try {
             $reflector = new ReflectionClass($concrete);
         } catch (ReflectionException $e) {
-            throw new BindingResolutionException("Target class [$concrete] does not exist.", 0, $e);
+            throw new BindingResolutionException(sprintf("Target class [%s] does not exist.", esc_html($concrete)), 0, esc_html($e));
         }
 
         // If the type is not instantiable, the developer is attempting to resolve
@@ -1030,7 +1032,7 @@ class Container implements ArrayAccess, ContainerContract
             $message = "Target [$concrete] is not instantiable.";
         }
 
-        throw new BindingResolutionException($message);
+        throw new BindingResolutionException(esc_html($message));
     }
 
     /**
@@ -1045,7 +1047,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
 
-        throw new BindingResolutionException($message);
+        throw new BindingResolutionException(esc_html($message));
     }
 
     /**

--- a/framework/Database/Eloquent/Model.php
+++ b/framework/Database/Eloquent/Model.php
@@ -423,6 +423,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $json = json_encode($this->jsonSerialize(), $options);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- The generated Exception has already escaped.
             throw JsonEncodingException::forModel($this, json_last_error_msg());
         }
 

--- a/framework/Database/Eloquent/ModelQueryBuilder.php
+++ b/framework/Database/Eloquent/ModelQueryBuilder.php
@@ -320,6 +320,8 @@ class ModelQueryBuilder
 
         $tableName = $this->model->getTable();
 
+		// Custom Query, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         return $wpdb->get_col("DESC " . $wpdb->prefix . $tableName, 0);
     }
 

--- a/framework/Database/Eloquent/ModelQueryBuilder.php
+++ b/framework/Database/Eloquent/ModelQueryBuilder.php
@@ -140,7 +140,10 @@ class ModelQueryBuilder
 
         $class = get_class($this->model);
 
-        throw new ModelNotFoundException("$class($id) not found.", 404);
+        throw new ModelNotFoundException(
+			sprintf("%s(%s) not found.", esc_html($class), esc_html($id)),
+			404
+        );
     }
 
     public function fresh()
@@ -165,7 +168,10 @@ class ModelQueryBuilder
 
         $class = get_class($this->model);
 
-        throw new ModelNotFoundException("There is no $class available.", 404);
+        throw new ModelNotFoundException(
+			sprintf("There is no %s available.", esc_html($class)),
+			404
+        );
     }
 
     public function firstOrNew(array $attributes, array $values = [])

--- a/framework/Database/QueryBuilder/QueryBuilderHandler.php
+++ b/framework/Database/QueryBuilder/QueryBuilderHandler.php
@@ -287,7 +287,10 @@ class QueryBuilderHandler
         );
 
         if (!in_array(strtolower($type), $allowedTypes)) {
-            throw new Exception($type . ' is not a known type.', 2);
+            throw new Exception(
+				sprintf("%s is not a known type.", esc_html($type)),
+				2
+            );
         }
 
         $queryArr = $this->adapterInstance->$type($this->statements, $dataToBePassed);

--- a/framework/Validation/ValidatesAttributes.php
+++ b/framework/Validation/ValidatesAttributes.php
@@ -407,6 +407,8 @@ trait ValidatesAttributes
             }
         }
 
+		// This is a custom table query with safe prepare, caching not applicable.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         return is_null($wpdb->get_row($wpdb->prepare($query, $bindings)));
     }
 }

--- a/framework/Validation/ValidatesAttributes.php
+++ b/framework/Validation/ValidatesAttributes.php
@@ -22,7 +22,13 @@ trait ValidatesAttributes
     protected function requireParameterCount($count, $parameters, $rule)
     {
         if (count($parameters) < $count) {
-            throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
+            throw new InvalidArgumentException(
+	            sprintf(
+		            'Validation rule %s requires at least %d parameters.',
+		            esc_html($rule),
+		            (int) $count
+	            )
+            );
         }
     }
 

--- a/framework/View/View.php
+++ b/framework/View/View.php
@@ -68,7 +68,9 @@ class View
             return $this;
         }
 
-        throw new InvalidArgumentException("The view file [{$this->path}] doesn't exists!");
+        throw new InvalidArgumentException(
+			sprintf("The view file [%s] doesn't exists!", esc_html( $this->path ))
+        );
     }
 
     /**

--- a/framework/View/View.php
+++ b/framework/View/View.php
@@ -51,6 +51,7 @@ class View
      */
     public function render($path, $data = [])
     {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
         echo $this->make($path, $data);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wp-smartpay",
-    "version": "2.7.8",
+    "version": "2.7.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wp-smartpay",
-            "version": "2.7.8",
+            "version": "2.7.13",
             "license": "MIT",
             "dependencies": {
                 "@wordpress/api-fetch": "^3.20.0",

--- a/resources/views/integrations.php
+++ b/resources/views/integrations.php
@@ -5,10 +5,10 @@
     <div class="container smartpay-integrations">
         <div class="d-flex align-items-center justify-content-between py-1 px-4 mt-3 text-white bg-dark rounded-top">
             <div class="lh-100">
-                <h2 class="text-white"><?php echo __('SmartPay - Integrations', 'smartpay'); ?></h2>
+                <h2 class="text-white"><?php echo esc_html__('SmartPay - Integrations', 'smartpay'); ?></h2>
             </div>
             <div>
-                <a class="btn btn-dark btn-sm" href="https://wpsmartpay.com/changelog/" target="_blank">v<?php echo SMARTPAY_VERSION; ?></a>
+                <a class="btn btn-dark btn-sm" href="https://wpsmartpay.com/changelog/" target="_blank">v<?php echo esc_html(SMARTPAY_VERSION); ?></a>
             </div>
         </div>
 
@@ -19,28 +19,28 @@
                         <div class="col-lg-3 col-md-4 integration">
                             <div class="card p-3 mb-3 d-flex">
                                 <div class="image m-0 mb-3 text-center" style="height: 90px;">
-                                    <img src="<?php echo $integration['cover']; ?>" class="img-fluid" alt="">
+                                    <img src="<?php echo esc_url($integration['cover']); ?>" class="img-fluid" alt="">
                                 </div>
                                 <div class="info">
-                                    <h3 class="name m-0 mb-1"><?php echo $integration['name']; ?></h3>
-                                    <p class="excerpt mb-1"><?php echo $integration['excerpt']; ?></p>
+                                    <h3 class="name m-0 mb-1"><?php echo esc_html($integration['name']); ?></h3>
+                                    <p class="excerpt mb-1"><?php echo wp_kses_post($integration['excerpt']); ?></p>
                                 </div>
 
                                 <div class="actions d-flex align-items-center mt-2 border-top pt-2">
                                     <?php $activated = in_array($namespace, smartpay_get_activated_integrations()); ?>
                                     <?php if (smartpay_integration_is_installed($integration)) : ?>
                                         <div class="custom-control custom-switch custom-switch-lg">
-                                            <input type="checkbox" class="custom-control-input" id="<?php echo 'integration_' . $namespace ?>" data-namespace="<?php echo $namespace ?>" <?php echo $activated ? 'checked' : ''; ?>>
-                                            <label class="custom-control-label" for="<?php echo 'integration_' . $namespace ?>">
+                                            <input type="checkbox" class="custom-control-input" id="<?php echo 'integration_' . esc_attr($namespace) ?>" data-namespace="<?php echo esc_attr($namespace) ?>" <?php echo $activated ? 'checked' : ''; ?>>
+                                            <label class="custom-control-label" for="<?php echo 'integration_' . esc_attr($namespace) ?>">
                                             </label>
                                         </div>
                                         <div class="d-flex bd-highlight">
                                             <span class="ml-2 integration-status p-2 bd-highlight">
-                                                <?php echo $activated ? __('Activated', 'smartpay') : __('Disabled', 'smartpay'); ?>
+                                                <?php echo $activated ? esc_html__('Activated', 'smartpay') : esc_html__('Disabled', 'smartpay'); ?>
                                             </span>
                                             <?php if (!empty($integration['setting_link']) && $activated == true) : ?>
                                                 <span class="ml-auto p-2 bd-highlight">
-                                                    <a href="<?php echo site_url() ?>/wp-admin/admin.php?page=smartpay-setting&<?php echo ($integration['setting_link']) ?>">
+                                                    <a href="<?php echo esc_url(site_url()) ?>/wp-admin/admin.php?page=smartpay-setting&<?php echo esc_url($integration['setting_link']) ?>">
                                                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-gear-fill" viewBox="0 0 16 16">
                                                             <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z" />
                                                         </svg>

--- a/resources/views/mail/payment-receipt/form-payment.php
+++ b/resources/views/mail/payment-receipt/form-payment.php
@@ -26,7 +26,7 @@ $form    = Form::find($formId);
       td,th,div,p,a,h1,h2,h3,h4,h5,h6 {font-family: "Segoe UI", sans-serif; mso-line-height-rule: exactly;}
     </style>
   <![endif]-->
-    <title><?php _e('Thank you for your payment', 'smartpay'); ?></title>
+    <title><?php esc_html_e('Thank you for your payment', 'smartpay'); ?></title>
     <style>
         .hover-no-underline:hover {
             text-decoration: none !important;
@@ -109,7 +109,7 @@ $form    = Form::find($formId);
 </head>
 
 <body style="margin: 0; padding: 0; width: 100%; word-break: break-word; -webkit-font-smoothing: antialiased; background-color: #f2f2f7">
-    <div role="article" aria-roledescription="email" aria-label="<?php _e('Thank you for your payment', 'smartpay'); ?>" lang="en">
+    <div role="article" aria-roledescription="email" aria-label="<?php esc_html_e('Thank you for your payment', 'smartpay'); ?>" lang="en">
         <table style="font-family: Arial, sans-serif; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
             <tr>
                 <td align="center" style="background-color: #f2f2f7" bgcolor="#f2f2f7">
@@ -120,8 +120,8 @@ $form    = Form::find($formId);
                                     <tr>
                                         <td>
                                             <div style="text-align: center">
-                                                <a href="<?php echo site_url(); ?>" style="text-decoration: none">
-                                                    <?php echo get_bloginfo('name'); ?>
+                                                <a href="<?php echo esc_url(site_url()); ?>" style="text-decoration: none">
+                                                    <?php echo esc_html(get_bloginfo('name')); ?>
                                                 </a>
                                             </div>
                                             <div class="sm-leading-64" style="line-height: 70px">&zwnj;</div>
@@ -129,14 +129,14 @@ $form    = Form::find($formId);
                                                 <tr>
                                                     <td class="sm-p-0" style="padding-left: 64px; padding-right: 64px">
                                                         <h1 class="sm-text-40px sm-leading-44" style="font-size: 28px; line-height: 56px; margin: 0; text-align: center; color: #5744cb">
-                                                            <?php _e('Thank you for your payment', 'smartpay'); ?>
+                                                            <?php esc_html_e('Thank you for your payment', 'smartpay'); ?>
                                                         </h1>
                                                     </td>
                                                 </tr>
                                             </table>
                                             <div class="sm-leading-16" style="line-height: 24px">&zwnj;</div>
                                             <p style="font-size: 16px; line-height: 24px; margin: 0; text-align: center; color: #a0a6b0">
-                                                <?php echo __('Payment ', 'smartpay') . ' #' . $payment->id; ?>
+                                                <?php echo esc_html__('Payment ', 'smartpay') . ' #' . esc_html($payment->id); ?>
                                             </p>
                                             <div class="sm-leading-40" style="line-height: 48px">&zwnj;</div>
                                             <div style="background-color: #d4d5d6; height: 1px; line-height: 1px">&nbsp;</div>
@@ -145,13 +145,13 @@ $form    = Form::find($formId);
                                                 <tr>
                                                     <th class="sm-w-full sm-block sm-pb-16" style="font-weight: 400; text-align: left; width: 50%" align="left">
                                                         <p class="sm-text-32px sm-leading-36" style="font-weight: 700; font-size: 28px; line-height: 44px; margin: 0px; color: #4f5a68">
-                                                            <?php echo smartpay_amount_format($payment->amount); ?>
+                                                            <?php echo esc_html(smartpay_amount_format($payment->amount)); ?>
                                                         </p>
                                                     </th>
                                                     <th class="sm-w-full sm-block" style="font-weight: 400; vertical-align: center; width: 50%" valign="center">
                                                         <div class="sm-text-left" style="text-align: right">
                                                             <!-- FIXME -->
-                                                            <a href="<?php echo site_url() . '/smartpay-customer-dashboard'; ?>" class="hover-no-underline" style="font-size: 16px; color: #986dff; text-decoration: underline"><?php _e('My Account', 'smartpay'); ?></a>
+                                                            <a href="<?php echo esc_url(site_url()) . '/smartpay-customer-dashboard'; ?>" class="hover-no-underline" style="font-size: 16px; color: #986dff; text-decoration: underline"><?php esc_html_e('My Account', 'smartpay'); ?></a>
                                                         </div>
                                                     </th>
                                                 </tr>
@@ -160,12 +160,12 @@ $form    = Form::find($formId);
                                             <table style="width: 100%" cellpadding="0" cellspacing="0" role="presentation">
                                                 <tr>
                                                     <td style="background-color: #ffffff; border-radius: 4px; padding: 32px 24px" bgcolor="#ffffff">
-                                                        <h3 style="font-weight: 400; font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68"><?php _e('Payment details', 'smartpay'); ?></h3>
+                                                        <h3 style="font-weight: 400; font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68"><?php esc_html_e('Payment details', 'smartpay'); ?></h3>
                                                         <div style="line-height: 24px">&zwnj;</div>
                                                         <table style="color: #4f5a68; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
                                                             <tr>
-                                                                <td style="font-size: 16px; line-height: 24px; color: #a0a6b0; vertical-align: top; width: 50%" valign="top"><?php echo $form->title; ?></td>
-                                                                <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo smartpay_amount_format($payment->data['total_amount']); ?></td>
+                                                                <td style="font-size: 16px; line-height: 24px; color: #a0a6b0; vertical-align: top; width: 50%" valign="top"><?php echo esc_html($form->title); ?></td>
+                                                                <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo esc_html(smartpay_amount_format($payment->data['total_amount'])); ?></td>
                                                             </tr>
                                                             <tr>
                                                                 <td colspan="2" style="padding-top: 16px; padding-bottom: 16px">
@@ -173,8 +173,8 @@ $form    = Form::find($formId);
                                                                 </td>
                                                             </tr>
                                                             <tr>
-                                                                <td style="font-weight: 700; font-size: 16px; line-height: 24px; vertical-align: top; width: 50%" valign="top"><?php _e('Total', 'smartpay'); ?></td>
-                                                                <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo smartpay_amount_format($payment->data['total_amount']); ?></td>
+                                                                <td style="font-weight: 700; font-size: 16px; line-height: 24px; vertical-align: top; width: 50%" valign="top"><?php esc_html_e('Total', 'smartpay'); ?></td>
+                                                                <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo esc_html(smartpay_amount_format($payment->data['total_amount'])); ?></td>
                                                             </tr>
                                                         </table>
                                                     </td>
@@ -189,9 +189,9 @@ $form    = Form::find($formId);
                                                     <td class="sm-w-full sm-block sm-pb-32" style="font-weight: 400; text-align: left; vertical-align: top; width: 50%" align="left" valign="top">
                                                         <h4 style="font-size: 16px; line-height: 24px; margin: 0 0 8px; color: #4f5a68">Customer details</h4>
                                                         <p style="font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68">
-                                                            <?php echo __('Name:', 'smartpay') . ' ' . $payment->customer->full_name; ?>
+                                                            <?php echo esc_html__('Name:', 'smartpay') . ' ' . esc_html($payment->customer->full_name); ?>
                                                             <br>
-                                                            <?php echo __('Email:', 'smartpay') . ' ' . $payment->customer->email; ?>
+                                                            <?php echo esc_html__('Email:', 'smartpay') . ' ' . esc_html($payment->customer->email); ?>
                                                             <br>
                                                         </p>
                                                     </td>
@@ -200,7 +200,7 @@ $form    = Form::find($formId);
                                             <div style="line-height: 64px">&zwnj;</div>
                                             <div style="background-color: #d4d5d6; height: 1px; line-height: 1px">&nbsp;</div>
                                             <div class="sm-leading-16" style="line-height: 32px">&zwnj;</div>
-                                            <p style="font-size: 14px; line-height: 20px; margin: 0; color: #a0a6b0"><?php echo __('You get this email because you sign up or purchase someting at ', 'smartpay') . get_bloginfo('name'); ?></p>
+                                            <p style="font-size: 14px; line-height: 20px; margin: 0; color: #a0a6b0"><?php echo esc_html__('You get this email because you sign up or purchase someting at ', 'smartpay') . esc_html(get_bloginfo('name')); ?></p>
                                             <div class="sm-leading-16" style="line-height: 32px">&zwnj;</div>
                                         </td>
                                     </tr>

--- a/resources/views/mail/payment-receipt/form-payment.php
+++ b/resources/views/mail/payment-receipt/form-payment.php
@@ -109,7 +109,7 @@ $form    = Form::find($formId);
 </head>
 
 <body style="margin: 0; padding: 0; width: 100%; word-break: break-word; -webkit-font-smoothing: antialiased; background-color: #f2f2f7">
-    <div role="article" aria-roledescription="email" aria-label="<?php esc_html_e('Thank you for your payment', 'smartpay'); ?>" lang="en">
+    <div role="article" aria-roledescription="email" aria-label="<?php esc_attr_e('Thank you for your payment', 'smartpay'); ?>" lang="en">
         <table style="font-family: Arial, sans-serif; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
             <tr>
                 <td align="center" style="background-color: #f2f2f7" bgcolor="#f2f2f7">

--- a/resources/views/mail/payment-receipt/product-purchase.php
+++ b/resources/views/mail/payment-receipt/product-purchase.php
@@ -109,7 +109,7 @@ $product       = Product::with('parent')->find($productId);
 </head>
 
 <body style="margin: 0; padding: 0; width: 100%; word-break: break-word; -webkit-font-smoothing: antialiased; background-color: #f2f2f7">
-<div role="article" aria-roledescription="email" aria-label="<?php esc_html_e('Thank you for your payment', 'smartpay'); ?>" lang="en">
+<div role="article" aria-roledescription="email" aria-label="<?php esc_attr_e('Thank you for your payment', 'smartpay'); ?>" lang="en">
     <table style="font-family: Arial, sans-serif; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
             <td align="center" style="background-color: #f2f2f7" bgcolor="#f2f2f7">

--- a/resources/views/mail/payment-receipt/product-purchase.php
+++ b/resources/views/mail/payment-receipt/product-purchase.php
@@ -26,7 +26,7 @@ $product       = Product::with('parent')->find($productId);
         td,th,div,p,a,h1,h2,h3,h4,h5,h6 {font-family: "Segoe UI", sans-serif; mso-line-height-rule: exactly;}
     </style>
     <![endif]-->
-    <title><?php _e('Thank you for your payment', 'smartpay'); ?></title>
+    <title><?php esc_html_e('Thank you for your payment', 'smartpay'); ?></title>
     <style>
         .hover-no-underline:hover {
             text-decoration: none !important;
@@ -109,7 +109,7 @@ $product       = Product::with('parent')->find($productId);
 </head>
 
 <body style="margin: 0; padding: 0; width: 100%; word-break: break-word; -webkit-font-smoothing: antialiased; background-color: #f2f2f7">
-<div role="article" aria-roledescription="email" aria-label="<?php _e('Thank you for your payment', 'smartpay'); ?>" lang="en">
+<div role="article" aria-roledescription="email" aria-label="<?php esc_html_e('Thank you for your payment', 'smartpay'); ?>" lang="en">
     <table style="font-family: Arial, sans-serif; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
             <td align="center" style="background-color: #f2f2f7" bgcolor="#f2f2f7">
@@ -120,8 +120,8 @@ $product       = Product::with('parent')->find($productId);
                                 <tr>
                                     <td>
                                         <div style="text-align: center">
-                                            <a href="<?php echo site_url(); ?>" style="text-decoration: none">
-                                                <?php echo get_bloginfo('name'); ?>
+                                            <a href="<?php echo esc_url(site_url()); ?>" style="text-decoration: none">
+                                                <?php echo esc_html(get_bloginfo('name')); ?>
                                             </a>
                                         </div>
                                         <div class="sm-leading-64" style="line-height: 70px">&zwnj;</div>
@@ -129,14 +129,14 @@ $product       = Product::with('parent')->find($productId);
                                             <tr>
                                                 <td class="sm-p-0" style="padding-left: 64px; padding-right: 64px">
                                                     <h1 class="sm-text-40px sm-leading-44" style="font-size: 28px; line-height: 56px; margin: 0; text-align: center; color: #5744cb">
-                                                        <?php _e('Thank you for your payment', 'smartpay'); ?>
+                                                        <?php esc_html_e('Thank you for your payment', 'smartpay'); ?>
                                                     </h1>
                                                 </td>
                                             </tr>
                                         </table>
                                         <div class="sm-leading-16" style="line-height: 24px">&zwnj;</div>
                                         <p style="font-size: 16px; line-height: 24px; margin: 0; text-align: center; color: #a0a6b0">
-                                            <?php echo __('Payment ', 'smartpay') . ' #' . $payment->id; ?>
+                                            <?php echo esc_html__('Payment ', 'smartpay') . ' #' . esc_html($payment->id); ?>
                                         </p>
                                         <div class="sm-leading-40" style="line-height: 48px">&zwnj;</div>
                                         <div style="background-color: #d4d5d6; height: 1px; line-height: 1px">&nbsp;</div>
@@ -145,13 +145,13 @@ $product       = Product::with('parent')->find($productId);
                                             <tr>
                                                 <th class="sm-w-full sm-block sm-pb-16" style="font-weight: 400; text-align: left; width: 50%" align="left">
                                                     <p class="sm-text-32px sm-leading-36" style="font-weight: 700; font-size: 28px; line-height: 44px; margin: 0px; color: #4f5a68">
-                                                        <?php echo smartpay_amount_format($payment->amount); ?>
+                                                        <?php echo esc_html(smartpay_amount_format($payment->amount)); ?>
                                                     </p>
                                                 </th>
                                                 <th class="sm-w-full sm-block" style="font-weight: 400; vertical-align: center; width: 50%" valign="center">
                                                     <div class="sm-text-left" style="text-align: right">
                                                         <!-- FIXME: Set dynamic URL -->
-                                                        <a href="<?php echo site_url() . '/smartpay-customer-dashboard'; ?>" class="hover-no-underline" style="font-size: 16px; color: #986dff; text-decoration: underline"><?php _e('My Account', 'smartpay'); ?></a>
+                                                        <a href="<?php echo esc_url(site_url() . '/smartpay-customer-dashboard'); ?>" class="hover-no-underline" style="font-size: 16px; color: #986dff; text-decoration: underline"><?php esc_html_e('My Account', 'smartpay'); ?></a>
                                                     </div>
                                                 </th>
                                             </tr>
@@ -160,12 +160,12 @@ $product       = Product::with('parent')->find($productId);
                                         <table style="width: 100%" cellpadding="0" cellspacing="0" role="presentation">
                                             <tr>
                                                 <td style="background-color: #ffffff; border-radius: 4px; padding: 32px 24px" bgcolor="#ffffff">
-                                                    <h3 style="font-weight: 400; font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68"><?php _e('Order details', 'smartpay'); ?></h3>
+                                                    <h3 style="font-weight: 400; font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68"><?php esc_html_e('Order details', 'smartpay'); ?></h3>
                                                     <div style="line-height: 24px">&zwnj;</div>
                                                     <table style="color: #4f5a68; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
                                                         <tr>
-                                                            <td style="font-size: 16px; line-height: 24px; color: #a0a6b0; vertical-align: top; width: 50%" valign="top"><?php echo $product->formatted_title; ?></td>
-                                                            <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo smartpay_amount_format($payment->data['product_price']); ?></td>
+                                                            <td style="font-size: 16px; line-height: 24px; color: #a0a6b0; vertical-align: top; width: 50%" valign="top"><?php echo esc_html($product->formatted_title); ?></td>
+                                                            <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo esc_html(smartpay_amount_format($payment->data['product_price'])); ?></td>
                                                         </tr>
                                                         <tr>
                                                             <td colspan="2" style="padding-top: 16px; padding-bottom: 16px">
@@ -173,8 +173,8 @@ $product       = Product::with('parent')->find($productId);
                                                             </td>
                                                         </tr>
                                                         <tr>
-                                                            <td style="font-weight: 700; font-size: 16px; line-height: 24px; vertical-align: top; width: 50%" valign="top"><?php _e('Total', 'smartpay'); ?></td>
-                                                            <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo smartpay_amount_format($payment->data['total_amount']); ?></td>
+                                                            <td style="font-weight: 700; font-size: 16px; line-height: 24px; vertical-align: top; width: 50%" valign="top"><?php esc_html_e('Total', 'smartpay'); ?></td>
+                                                            <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><?php echo esc_html(smartpay_amount_format($payment->data['total_amount'])); ?></td>
                                                         </tr>
                                                     </table>
                                                 </td>
@@ -186,13 +186,13 @@ $product       = Product::with('parent')->find($productId);
                                             <table style="width: 100%" cellpadding="0" cellspacing="0" role="presentation">
                                                 <tr>
                                                     <td style="background-color: #ffffff; border-radius: 4px; padding: 32px 24px" bgcolor="#ffffff">
-                                                        <h3 style="font-weight: 400; font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68"><?php _e('Downloads', 'smartpay'); ?></h3>
+                                                        <h3 style="font-weight: 400; font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68"><?php esc_html_e('Downloads', 'smartpay'); ?></h3>
                                                         <div style="line-height: 24px">&zwnj;</div>
                                                         <table style="color: #4f5a68; width: 100%" cellpadding="0" cellspacing="0" role="presentation">
                                                             <?php foreach ($product->files as $file) : ?>
                                                                 <tr>
-                                                                    <td style="font-size: 16px; line-height: 24px; color: #a0a6b0; vertical-align: top; width: 50%" valign="top"><?php echo $file['name'] ?? 'Download Item'; ?></td>
-                                                                    <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><a href="<?php echo smartpay()->make(Downloader::class)->getDownloadUrl($file['id'], $payment->id, $product->id); ?>" class="btn btn-sm btn-primary mr-1"><?php _e('Download', 'smartpay'); ?></a></td>
+                                                                    <td style="font-size: 16px; line-height: 24px; color: #a0a6b0; vertical-align: top; width: 50%" valign="top"><?php echo esc_html($file['name'] ?? 'Download Item'); ?></td>
+                                                                    <td style="font-weight: 700; font-size: 16px; line-height: 24px; text-align: right; vertical-align: top; width: 50%" align="right" valign="top"><a href="<?php echo esc_url(smartpay()->make(Downloader::class)->getDownloadUrl($file['id'], $payment->id, $product->id)); ?>" class="btn btn-sm btn-primary mr-1"><?php esc_html_e('Download', 'smartpay'); ?></a></td>
                                                                 </tr>
                                                                 <tr>
                                                                     <td colspan="2" style="padding-top: 16px; padding-bottom: 16px">
@@ -209,7 +209,7 @@ $product       = Product::with('parent')->find($productId);
                                                     <strong>
                                                         [N:B] - The download links will stay valid for 7 days.
                                                         Once the link has expired you can still download your product/s from your
-                                                        <a href="<?php echo site_url() . '/smartpay-customer-dashboard'; ?>">account dashboard</a>.
+                                                        <a href="<?php echo esc_url(site_url() . '/smartpay-customer-dashboard'); ?>">account dashboard</a>.
                                                     </strong>
                                                 </p>
                                             </div>
@@ -223,9 +223,9 @@ $product       = Product::with('parent')->find($productId);
                                                 <td class="sm-w-full sm-block sm-pb-32" style="font-weight: 400; text-align: left; vertical-align: top; width: 50%" align="left" valign="top">
                                                     <h4 style="font-size: 16px; line-height: 24px; margin: 0 0 8px; color: #4f5a68">Customer details</h4>
                                                     <p style="font-size: 16px; line-height: 24px; margin: 0; color: #4f5a68">
-                                                        <?php echo __('Name:', 'smartpay') . ' ' . $payment->customer->full_name; ?>
+                                                        <?php echo esc_html__('Name:', 'smartpay') . ' ' . esc_html($payment->customer->full_name); ?>
                                                         <br>
-                                                        <?php echo __('Email:', 'smartpay') . ' ' . $payment->customer->email; ?>
+                                                        <?php echo esc_html__('Email:', 'smartpay') . ' ' . esc_html($payment->customer->email); ?>
                                                         <br>
                                                     </p>
                                                 </td>
@@ -234,7 +234,7 @@ $product       = Product::with('parent')->find($productId);
                                         <div style="line-height: 64px">&zwnj;</div>
                                         <div style="background-color: #d4d5d6; height: 1px; line-height: 1px">&nbsp;</div>
                                         <div class="sm-leading-16" style="line-height: 32px">&zwnj;</div>
-                                        <p style="font-size: 14px; line-height: 20px; margin: 0; color: #a0a6b0"><?php echo __('You have received this email because you signed up, donated or made a transaction at ', 'smartpay') . get_bloginfo('name'); ?></p>
+                                        <p style="font-size: 14px; line-height: 20px; margin: 0; color: #a0a6b0"><?php echo esc_html__('You have received this email because you signed up, donated or made a transaction at ', 'smartpay') . esc_html(get_bloginfo('name')); ?></p>
                                         <div class="sm-leading-16" style="line-height: 32px">&zwnj;</div>
                                     </td>
                                 </tr>

--- a/resources/views/settings.php
+++ b/resources/views/settings.php
@@ -107,7 +107,7 @@ ob_start();
                                         <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
                                         </svg>';
                     echo '<li class="ml-auto bd-highlight nav-item m-0">';
-                    echo '<span class="btn-sm btn-secondary disabled">' . esc_html($test_mode_svg) . esc_html($payment_mode) . '</span>';
+                    echo '<span class="btn-sm btn-secondary disabled">' . wp_kses_post($test_mode_svg) . wp_kses_post($payment_mode) . '</span>';
                     echo '</li>';
                     echo '</ul>';
                 }
@@ -137,4 +137,4 @@ ob_start();
     </div>
     <!-- container end -->
 </div>
-<?php echo wp_kses_post(ob_get_clean());
+<?php echo ob_get_clean();

--- a/resources/views/settings.php
+++ b/resources/views/settings.php
@@ -137,4 +137,6 @@ ob_start();
     </div>
     <!-- container end -->
 </div>
-<?php echo ob_get_clean();
+<?php
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
+echo ob_get_clean();

--- a/resources/views/settings.php
+++ b/resources/views/settings.php
@@ -40,17 +40,17 @@ if (false === $has_main_settings) {
 
 ob_start();
 ?>
-<div class="smartpay <?php echo 'settings-' . $active_tab; ?>">
+<div class="smartpay <?php echo 'settings-' . esc_attr($active_tab); ?>">
     <div class="wrap container">
         <h1 class="wp-heading-inline"></h1>
     </div>
     <div class="container">
         <div class="d-flex align-items-center justify-content-between py-1 px-4 mt-3 text-white bg-dark rounded-top">
             <div class="lh-100">
-                <h2 class="text-white"><?php _e('SmartPay Settings', 'smartpay'); ?></h2>
+                <h2 class="text-white"><?php esc_html_e('SmartPay Settings', 'smartpay'); ?></h2>
             </div>
             <div>
-                <a class="btn btn-dark btn-sm" href="https://wpsmartpay.com/changelog/" target="_blank">v<?php echo SMARTPAY_VERSION; ?></a>
+                <a class="btn btn-dark btn-sm" href="https://wpsmartpay.com/changelog/" target="_blank">v<?php echo esc_html(SMARTPAY_VERSION); ?></a>
             </div>
         </div>
 
@@ -69,7 +69,7 @@ ob_start();
 
                         $active = $active_tab == $tab_id ? ' active' : '';
                         echo '<li class="nav-item">';
-                        echo '<a href="' . esc_url($tab_url) . '" class="nav-link' . $active . '">';
+                        echo '<a href="' . esc_url($tab_url) . '" class="nav-link' . esc_attr($active) . '">';
                         echo esc_html($tab_name);
                         echo '</a>';
                         echo '</li>';
@@ -96,7 +96,7 @@ ob_start();
                         if ($section == $section_id) {
                             $class .= ' active bg-secondary';
                         }
-                        echo '<a class="' . $class . '" href="' . esc_url($tab_url) . '">' . $section_name . '</a>';
+                        echo '<a class="' . esc_attr($class) . '" href="' . esc_url($tab_url) . '">' . esc_html($section_name) . '</a>';
 
                         echo '</li>';
                     }
@@ -107,7 +107,7 @@ ob_start();
                                         <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
                                         </svg>';
                     echo '<li class="ml-auto bd-highlight nav-item m-0">';
-                    echo '<span class="btn-sm btn-secondary disabled">' . $test_mode_svg . $payment_mode . '</span>';
+                    echo '<span class="btn-sm btn-secondary disabled">' . esc_html($test_mode_svg) . esc_html($payment_mode) . '</span>';
                     echo '</li>';
                     echo '</ul>';
                 }
@@ -128,7 +128,7 @@ ob_start();
                         <?php submit_button(__('Save Changes', 'smartpay'), 'btn btn-primary'); ?>
                     <?php endif; ?>
                     <?php if ($active_tab === 'debug_log') : ?>
-                        <button class="btn btn-primary smartpay-clear-debug-log"><?php echo __('Clear Log', 'smartpay') ?></button>
+                        <button class="btn btn-primary smartpay-clear-debug-log"><?php echo esc_html__('Clear Log', 'smartpay') ?></button>
                     <?php endif; ?>
                 </form>
             </div>
@@ -137,4 +137,4 @@ ob_start();
     </div>
     <!-- container end -->
 </div>
-<?php echo ob_get_clean();
+<?php echo wp_kses_post(ob_get_clean());

--- a/resources/views/shortcodes/customer_dashboard.php
+++ b/resources/views/shortcodes/customer_dashboard.php
@@ -15,18 +15,18 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                         <img class="rounded-circle" src="<?php echo esc_url(get_avatar_url(get_current_user_id())); ?>" alt="Profile image">
                     </div>
                     <div class="text-center">
-                        <h3 class="mt-4 mb-2"><?php echo ($customer->full_name ?? ''); ?></h3>
-                        <p class="my-0" class="text-muted"><?php echo $customer->email ?? ''; ?></p>
+                        <h3 class="mt-4 mb-2"><?php echo esc_html($customer->full_name ?? ''); ?></h3>
+                        <p class="my-0" class="text-muted"><?php echo esc_html($customer->email ?? ''); ?></p>
                     </div>
                 </div>
 
                 <div class="mt-5">
                     <nav class="nav justify-content-center nav-pills mb-4" role="tablist">
-                        <a class="nav-link mx-2 px-4 active" data-toggle="pill" href="#payments" role="tab"><?php _e('Payments', 'smartpay'); ?></a>
+                        <a class="nav-link mx-2 px-4 active" data-toggle="pill" href="#payments" role="tab"><?php esc_html_e('Payments', 'smartpay'); ?></a>
 
-                        <a class="nav-link mx-2 px-4" data-toggle="pill" href="#downloads" role="tab"><?php _e('Downloads', 'smartpay'); ?></a>
+                        <a class="nav-link mx-2 px-4" data-toggle="pill" href="#downloads" role="tab"><?php esc_html_e('Downloads', 'smartpay'); ?></a>
 
-                        <a class="nav-link mx-2 px-4" data-toggle="pill" href="#profile" role="tab"><?php _e('Profile', 'smartpay'); ?></a>
+                        <a class="nav-link mx-2 px-4" data-toggle="pill" href="#profile" role="tab"><?php esc_html_e('Profile', 'smartpay'); ?></a>
 
                         <?php do_action('smartpay_customer_dashboard_tab_link'); ?>
                     </nav>
@@ -37,7 +37,7 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                     <?php if (!count($customer->payments)) : ?>
                                         <div class="card">
                                             <div class="card-body py-5">
-                                                <p class="text-info  m-0 text-center"><?php _e('You don\'t have any payment yet.', 'smartpay'); ?></p>
+                                                <p class="text-info  m-0 text-center"><?php esc_html_e('You don\'t have any payment yet.', 'smartpay'); ?></p>
                                             </div>
                                         </div>
                                     <?php else : ?>
@@ -45,10 +45,10 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                             <table class="table table-hover">
                                                 <thead>
                                                     <tr>
-                                                        <th scope="col"><?php _e('Order ID', 'smartpay'); ?></th>
-                                                        <th scope="col"><?php _e('Date', 'smartpay'); ?></th>
-                                                        <th scope="col"><?php _e('Status', 'smartpay'); ?></th>
-                                                        <th scope="col"><?php _e('Amount', 'smartpay'); ?></th>
+                                                        <th scope="col"><?php esc_html_e('Order ID', 'smartpay'); ?></th>
+                                                        <th scope="col"><?php esc_html_e('Date', 'smartpay'); ?></th>
+                                                        <th scope="col"><?php esc_html_e('Status', 'smartpay'); ?></th>
+                                                        <th scope="col"><?php esc_html_e('Amount', 'smartpay'); ?></th>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -59,8 +59,8 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
 	                                                        $payment_detail_url = add_query_arg('smartpay-payment', $payment->uuid, smartpay_get_payment_success_page_uri());
 	                                                        ?>
                                                             <th scope="row">
-                                                                <a href="<?php echo $payment_detail_url; ?>" target="_blank">
-                                                                    <?php echo '#' . $payment->id; ?>
+                                                                <a href="<?php echo esc_url($payment_detail_url); ?>" target="_blank">
+                                                                    <?php echo '#' . esc_html($payment->id); ?>
                                                                 </a>
                                                             </th>
                                                             <td>
@@ -68,13 +68,13 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                                                 <?php
                                                                     $date = $payment->completed_at ?? $payment->created_at;
                                                                 ?>
-                                                                <?php echo mysql2date('F j, Y', $date) ; ?>
+                                                                <?php echo esc_html(mysql2date('F j, Y', $date)) ; ?>
                                                             </td>
-                                                            <td class="<?php echo 'completed' == $payment->status ? 'text-success' : 'text-danger'; ?>">
-                                                                <?php echo $payment->status; ?></td>
+                                                            <td class="<?php echo esc_attr('completed' == $payment->status ? 'text-success' : 'text-danger'); ?>">
+                                                                <?php echo esc_html($payment->status); ?></td>
                                                             <td class="text-muted">
-                                                                <strong class="<?php echo 'completed' == $payment->status ? 'text-success' : 'text-danger'; ?>">
-                                                                    <?php echo smartpay_amount_format($payment->amount, $payment->currency); ?>
+                                                                <strong class="<?php echo esc_attr('completed' == $payment->status ? 'text-success' : 'text-danger'); ?>">
+                                                                    <?php echo esc_html(smartpay_amount_format($payment->amount, $payment->currency)); ?>
                                                                 </strong>
                                                             </td>
                                                         </tr>
@@ -89,7 +89,7 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                     <?php if (!count($activePayments)) : ?>
                                         <div class="card">
                                             <div class="card-body py-5">
-                                                <p class="text-info  m-0 text-center"><?php _e('You don\'t have downloadable item yet!', 'smartpay'); ?></p>
+                                                <p class="text-info  m-0 text-center"><?php esc_html_e('You don\'t have downloadable item yet!', 'smartpay'); ?></p>
                                             </div>
                                         </div>
                                     <?php else : ?>
@@ -106,41 +106,41 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                             <?php else : ?>
                                                 <div class="border mb-3 product">
                                                     <div class="p-3 product--header">
-                                                        <div class="d-flex align-items-center" data-toggle="collapse" data-target="#collapse-payment-<?php echo $index; ?>">
+                                                        <div class="d-flex align-items-center" data-toggle="collapse" data-target="#collapse-payment-<?php echo esc_attr($index); ?>">
                                                             <?php $covers = $product->isParent() ? $product->covers : $product->parent->covers; ?>
                                                             <?php if (count($covers)) : ?>
                                                                 <div class="product--image mr-3">
-                                                                    <img src="<?php echo $covers[0]['icon']; ?>" class="border" alt="">
+                                                                    <img src="<?php echo esc_url($covers[0]['icon']); ?>" class="border" alt="">
                                                                 </div>
                                                             <?php endif; ?>
                                                             <div class="flex-grow-1">
-                                                                <h5 class="my-0"><?php echo $product->formatted_title; ?></h5>
+                                                                <h5 class="my-0"><?php echo esc_html($product->formatted_title); ?></h5>
                                                             </div>
                                                         </div>
                                                     </div>
 
-                                                    <div class="p-3 bg-light collapse show" id="collapse-payment-<?php echo $index; ?>">
+                                                    <div class="p-3 bg-light collapse show" id="collapse-payment-<?php echo esc_attr($index); ?>">
                                                         <?php $downloadFiles = $product->files; ?>
                                                         <?php if ($downloadFiles) : ?>
-                                                            <p><?php _e('Files', 'smartpay'); ?></p>
+                                                            <p><?php esc_html_e('Files', 'smartpay'); ?></p>
                                                             <ul class="list-group">
                                                                 <?php foreach ($downloadFiles as $file) : ?>
                                                                     <li class="list-group-item p-2">
                                                                         <div class="d-flex align-items-center">
-                                                                            <img src="<?php echo $file['icon']; ?>" class="download-item-icon" alt="">
+                                                                            <img src="<?php echo esc_url($file['icon']); ?>" class="download-item-icon" alt="">
                                                                             <div class="d-flex flex-grow-1 flex-column ml-3">
-                                                                                <p class="m-0"><?php echo $file['name'] ?? ''; ?></p>
+                                                                                <p class="m-0"><?php echo esc_html($file['name'] ?? ''); ?></p>
                                                                                 <div class="d-flex flex-row justify-content-between text-muted m-0">
-                                                                                    <small><?php _e(sprintf('Size: ', 'smartpay') . $file['size'] ?? ''); ?></small>
+                                                                                    <small><?php esc_html_e(sprintf('Size: ', 'smartpay') . $file['size'] ?? ''); ?></small>
                                                                                 </div>
                                                                             </div>
-                                                                            <a href="<?php echo smartpay()->make(Downloader::class)->getDownloadUrl($file['id'], $payment->id, $product->id); ?>" class="btn btn-sm btn-primary btn--download"><?php _e('Download', 'smartpay'); ?></a>
+                                                                            <a href="<?php echo esc_url(smartpay()->make(Downloader::class)->getDownloadUrl($file['id'], $payment->id, $product->id)); ?>" class="btn btn-sm btn-primary btn--download"><?php esc_html_e('Download', 'smartpay'); ?></a>
                                                                         </div>
                                                                     </li>
                                                                 <?php endforeach; ?>
                                                             </ul>
                                                         <?php else : ?>
-                                                            <p class="mb-0 text-center"><?php _e('This item has no download file.', 'smartpay'); ?></p>
+                                                            <p class="mb-0 text-center"><?php esc_html_e('This item has no download file.', 'smartpay'); ?></p>
                                                         <?php endif; ?>
                                                     </div>
                                                 </div>
@@ -159,38 +159,38 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                         <input type="hidden" name="customer_id" value="<?php echo esc_attr($customer->id); ?>">
                                         <div class="form-row mb-2">
                                             <div class="form-group col">
-                                                <label for="first_name"><?php _e('First Name', 'smartpay'); ?></label>
-                                                <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo esc_attr($customer->first_name ?? '') ?>" placeholder="<?php _e('First Name', 'smartpay'); ?>">
+                                                <label for="first_name"><?php esc_html_e('First Name', 'smartpay'); ?></label>
+                                                <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo esc_attr($customer->first_name ?? '') ?>" placeholder="<?php esc_html_e('First Name', 'smartpay'); ?>">
                                             </div>
                                             <div class="form-group col">
-                                                <label for="last_name"><?php _e('Last Name', 'smartpay'); ?></label>
-                                                <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo esc_attr($customer->last_name ?? '') ?>" placeholder="<?php _e('Last Name', 'smartpay'); ?>">
+                                                <label for="last_name"><?php esc_html_e('Last Name', 'smartpay'); ?></label>
+                                                <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo esc_attr($customer->last_name ?? '') ?>" placeholder="<?php esc_html_e('Last Name', 'smartpay'); ?>">
                                             </div>
                                         </div>
 
                                         <div class="form-group mb-4">
-                                            <label for="email"><?php _e('Email', 'smartpay'); ?></label>
-                                            <input type="email" name="email" id="email" class="form-control" value="<?php echo esc_attr($customer->email ?? '') ?>" placeholder=" <?php _e('Email', 'smartpay'); ?>">
+                                            <label for="email"><?php esc_html_e('Email', 'smartpay'); ?></label>
+                                            <input type="email" name="email" id="email" class="form-control" value="<?php echo esc_attr($customer->email ?? '') ?>" placeholder=" <?php esc_html_e('Email', 'smartpay'); ?>">
                                         </div>
                                         <?php $userinfo = get_userdata($customer->id); ?>
                                         <div class="form-group mb-4">
-                                            <label><?php _e('Username', 'smartpay'); ?></label>
-                                            <input type="text" class="form-control" placeholder="<?php _e('Username', 'smartpay'); ?>" value="<?php echo $userinfo->user_login ?? '' ?>" disabled>
+                                            <label><?php esc_html_e('Username', 'smartpay'); ?></label>
+                                            <input type="text" class="form-control" placeholder="<?php esc_html_e('Username', 'smartpay'); ?>" value="<?php echo esc_attr($userinfo->user_login ?? '') ?>" disabled>
                                         </div>
 
                                         <div class="form-row mb-2">
                                             <div class="form-group col-6">
-                                                <label><?php _e('Password', 'smartpay'); ?></label>
-                                                <input type="password" name="password" id="password" class="form-control" placeholder="<?php _e('Password', 'smartpay'); ?>">
-                                                <small class="form-text text-muted"><?php _e('If you don\'t want to change password, then ignore this fields.', 'smartpay'); ?></small>
+                                                <label><?php esc_html_e('Password', 'smartpay'); ?></label>
+                                                <input type="password" name="password" id="password" class="form-control" placeholder="<?php esc_html_e('Password', 'smartpay'); ?>">
+                                                <small class="form-text text-muted"><?php esc_html_e('If you don\'t want to change password, then ignore this fields.', 'smartpay'); ?></small>
                                             </div>
                                             <div class="form-group col-6">
-                                                <label><?php _e('Confirm Password', 'smartpay'); ?></label>
-                                                <input type="password" name="password_confirm" id="password_confirm" class="form-control" placeholder="<?php _e('Confirm Password', 'smartpay'); ?>">
+                                                <label><?php esc_html_e('Confirm Password', 'smartpay'); ?></label>
+                                                <input type="password" name="password_confirm" id="password_confirm" class="form-control" placeholder="<?php esc_html_e('Confirm Password', 'smartpay'); ?>">
                                             </div>
                                         </div>
                                         <div class="d-flex justify-content-center mt-4">
-                                            <button type="submit" class="btn btn-primary px-5"><?php _e('Update', 'smartpay'); ?></button>
+                                            <button type="submit" class="btn btn-primary px-5"><?php esc_html_e('Update', 'smartpay'); ?></button>
                                         </div>
                                     </form>
                                 </div>

--- a/resources/views/shortcodes/customer_dashboard.php
+++ b/resources/views/shortcodes/customer_dashboard.php
@@ -160,33 +160,33 @@ $activePayments = $customer->payments()->where('status', 'completed')->get();
                                         <div class="form-row mb-2">
                                             <div class="form-group col">
                                                 <label for="first_name"><?php esc_html_e('First Name', 'smartpay'); ?></label>
-                                                <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo esc_attr($customer->first_name ?? '') ?>" placeholder="<?php esc_html_e('First Name', 'smartpay'); ?>">
+                                                <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo esc_attr($customer->first_name ?? '') ?>" placeholder="<?php esc_attr_e('First Name', 'smartpay'); ?>">
                                             </div>
                                             <div class="form-group col">
                                                 <label for="last_name"><?php esc_html_e('Last Name', 'smartpay'); ?></label>
-                                                <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo esc_attr($customer->last_name ?? '') ?>" placeholder="<?php esc_html_e('Last Name', 'smartpay'); ?>">
+                                                <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo esc_attr($customer->last_name ?? '') ?>" placeholder="<?php esc_attr_e('Last Name', 'smartpay'); ?>">
                                             </div>
                                         </div>
 
                                         <div class="form-group mb-4">
                                             <label for="email"><?php esc_html_e('Email', 'smartpay'); ?></label>
-                                            <input type="email" name="email" id="email" class="form-control" value="<?php echo esc_attr($customer->email ?? '') ?>" placeholder=" <?php esc_html_e('Email', 'smartpay'); ?>">
+                                            <input type="email" name="email" id="email" class="form-control" value="<?php echo esc_attr($customer->email ?? '') ?>" placeholder=" <?php esc_attr_e('Email', 'smartpay'); ?>">
                                         </div>
                                         <?php $userinfo = get_userdata($customer->id); ?>
                                         <div class="form-group mb-4">
                                             <label><?php esc_html_e('Username', 'smartpay'); ?></label>
-                                            <input type="text" class="form-control" placeholder="<?php esc_html_e('Username', 'smartpay'); ?>" value="<?php echo esc_attr($userinfo->user_login ?? '') ?>" disabled>
+                                            <input type="text" class="form-control" placeholder="<?php esc_attr_e('Username', 'smartpay'); ?>" value="<?php echo esc_attr($userinfo->user_login ?? '') ?>" disabled>
                                         </div>
 
                                         <div class="form-row mb-2">
                                             <div class="form-group col-6">
                                                 <label><?php esc_html_e('Password', 'smartpay'); ?></label>
-                                                <input type="password" name="password" id="password" class="form-control" placeholder="<?php esc_html_e('Password', 'smartpay'); ?>">
+                                                <input type="password" name="password" id="password" class="form-control" placeholder="<?php esc_attr_e('Password', 'smartpay'); ?>">
                                                 <small class="form-text text-muted"><?php esc_html_e('If you don\'t want to change password, then ignore this fields.', 'smartpay'); ?></small>
                                             </div>
                                             <div class="form-group col-6">
                                                 <label><?php esc_html_e('Confirm Password', 'smartpay'); ?></label>
-                                                <input type="password" name="password_confirm" id="password_confirm" class="form-control" placeholder="<?php esc_html_e('Confirm Password', 'smartpay'); ?>">
+                                                <input type="password" name="password_confirm" id="password_confirm" class="form-control" placeholder="<?php esc_attr_e('Confirm Password', 'smartpay'); ?>">
                                             </div>
                                         </div>
                                         <div class="d-flex justify-content-center mt-4">

--- a/resources/views/shortcodes/form.php
+++ b/resources/views/shortcodes/form.php
@@ -34,7 +34,7 @@ $has_payment_error = false;
             </div>
         </div>
         <button type="button" class="btn btn-success open-product-modal m-1">
-            <?php _e($label ? : 'Pay now', 'smartpay'); ?>
+            <?php esc_html_e($label ? : 'Pay now', 'smartpay'); ?>
         </button>
     </div>
 </div>

--- a/resources/views/shortcodes/payment_receipt.php
+++ b/resources/views/shortcodes/payment_receipt.php
@@ -13,14 +13,14 @@ if ($payment) : ?>
 		<?php do_action('smartpay_before_payment_receipt_data', $payment); ?>
 
         <tr>
-            <td><?php _e('Payment ID:', 'smartpay') ?></td>
+            <td><?php esc_html_e('Payment ID:', 'smartpay') ?></td>
             <td><?php echo esc_html($payment->id); ?></td>
         </tr>
 
         <tr>
-            <td><?php _e( $payment->type == 'Product Purchase' ? 'Product Name' : 'Form Name:', 'smartpay') ?></td>
+            <td><?php esc_html_e( $payment->type == 'Product Purchase' ? 'Product Name' : 'Form Name:', 'smartpay') ?></td>
             <td>
-                <a href="<?php echo smartpay_get_payment_product_or_form_name($payment->id)['preview'];?>" target="_blank">
+                <a href="<?php echo esc_url(smartpay_get_payment_product_or_form_name($payment->id)['preview']);?>" target="_blank">
 					<?php echo esc_html(smartpay_get_payment_product_or_form_name($payment->id)['name']); ?>
                 </a>
             </td>
@@ -28,32 +28,32 @@ if ($payment) : ?>
         </tr>
 
         <tr>
-            <td><?php _e('Name:', 'smartpay') ?></td>
+            <td><?php esc_html_e('Name:', 'smartpay') ?></td>
             <td><?php echo esc_html($payment->customer->first_name . ' ' . $payment->customer->last_name); ?></td>
         </tr>
         <tr>
-            <td><?php _e('Email:', 'smartpay') ?></td>
+            <td><?php esc_html_e('Email:', 'smartpay') ?></td>
             <td><?php echo esc_html($payment->email); ?></td>
         </tr>
         <tr>
-            <td><?php _e('Payment amount:', 'smartpay') ?></td>
+            <td><?php esc_html_e('Payment amount:', 'smartpay') ?></td>
             <td>
 				<?php
-				echo smartpay_amount_format($payment->amount);
+				echo esc_html(smartpay_amount_format($payment->amount));
 				?>
             </td>
         </tr>
 
 		<?php if ($payment->data['additional_info'] &&  ($additional_charge > 0 || $total_count > 0)): ?>
             <tr>
-                <td><?php _e('Subscription Info:', 'smartpay') ?></td>
+                <td><?php esc_html_e('Subscription Info:', 'smartpay') ?></td>
                 <td>
 					<?php
 					if ($additional_charge > 0) {
-						echo ('Additional charge '. smartpay_amount_format($additional_charge). ', ');
+						echo esc_html('Additional charge '. smartpay_amount_format($additional_charge). ', ');
 					}
 					if ($total_count > 0) {
-						echo ('  Will be billed '.$total_count .' times.');
+						echo esc_html('  Will be billed '.$total_count .' times.');
 					}
 					?>
                 </td>
@@ -61,19 +61,19 @@ if ($payment) : ?>
 		<?php endif; ?>
 
         <tr>
-            <td><?php _e('Payment gateway:', 'smartpay') ?></td>
+            <td><?php esc_html_e('Payment gateway:', 'smartpay') ?></td>
             <td>
 				<?php
 				if (smartpay_payment_gateways()[$payment->gateway]['checkout_label'] == 'Free'){
-					echo 'Free Purchase';
+					echo esc_html('Free Purchase');
 				}else{
-					echo smartpay_payment_gateways()[$payment->gateway]['checkout_label'] ?? ucfirst($payment->gateway);
+					echo esc_html(smartpay_payment_gateways()[$payment->gateway]['checkout_label'] ?? ucfirst($payment->gateway));
 				}
 				?>
             </td>
         </tr>
         <tr>
-            <td><?php _e('Payment status:', 'smartpay') ?></td>
+            <td><?php esc_html_e('Payment status:', 'smartpay') ?></td>
             <td><?php echo esc_html(ucfirst($payment->status)); ?></td>
         </tr>
 
@@ -84,10 +84,10 @@ if ($payment) : ?>
 				?>
 				<?php if ($product && $external_link && $external_link['allowExternalLink']): ?>
                     <tr>
-                        <td><?php _e('Resource', 'smartpay') ?></td>
+                        <td><?php esc_html_e('Resource', 'smartpay') ?></td>
                         <td>
-                            <a href="<?php echo $product['settings']['externalLink']['link']; ?>" target="_blank">
-								<?php echo $product['settings']['externalLink']['label'] ?>
+                            <a href="<?php echo esc_url($product['settings']['externalLink']['link']); ?>" target="_blank">
+								<?php echo esc_html($product['settings']['externalLink']['label']) ?>
                             </a>
                         </td>
                     </tr>
@@ -99,10 +99,10 @@ if ($payment) : ?>
 				?>
 				<?php if ($form && $external_link && $external_link['allowExternalLink']): ?>
                     <tr>
-                        <td><?php _e('Resource', 'smartpay') ?></td>
+                        <td><?php esc_html_e('Resource', 'smartpay') ?></td>
                         <td>
-                            <a href="<?php echo $form['settings']['externalLink']['link']; ?>" target="_blank">
-								<?php echo $form['settings']['externalLink']['label'] ?>
+                            <a href="<?php echo esc_url($form['settings']['externalLink']['link']); ?>" target="_blank">
+								<?php echo esc_html($form['settings']['externalLink']['label']) ?>
                             </a>
                         </td>
                     </tr>
@@ -124,20 +124,20 @@ if ($payment) : ?>
 	<?php if (strtolower($payment->status) == \SmartPay\Models\Payment::COMPLETED): ?>
 		<?php if ($product && count($product->files) > 0): ?>
             <!--    Do staff for download files-->
-            <h3><?php echo __( 'Files', 'smartpay' ); ?></h3>
+            <h3><?php echo esc_html__( 'Files', 'smartpay' ); ?></h3>
             <table>
                 <thead>
-                <th><?php _e('Name', 'smartpay') ?></th>
-                <th><?php _e('Action', 'smartpay') ?></th>
+                <th><?php esc_html_e('Name', 'smartpay') ?></th>
+                <th><?php esc_html_e('Action', 'smartpay') ?></th>
                 </thead>
                 <tbody>
 				<?php foreach ($product->files as $file) { ?>
                     <tr>
                         <td width="70%">
-							<?php echo $file['name']; ?>
+							<?php echo esc_html($file['name']); ?>
                         </td>
                         <td>
-                            <a href="<?php echo smartpay()->make(Downloader::class)->getDownloadUrl($file['id'], $payment->id, $product->id); ?>" class="btn btn-sm btn-primary btn--download"><?php _e('Download', 'smartpay'); ?></a>
+                            <a href="<?php echo esc_url(smartpay()->make(Downloader::class)->getDownloadUrl($file['id'], $payment->id, $product->id)); ?>" class="btn btn-sm btn-primary btn--download"><?php esc_html_e('Download', 'smartpay'); ?></a>
                         </td>
                     </tr>
 				<?php } ?>

--- a/resources/views/shortcodes/product.php
+++ b/resources/views/shortcodes/product.php
@@ -26,7 +26,7 @@
             </div>
         </div>
         <button type="button" class="btn btn-success open-product-modal m-1">
-            <?php _e($label ? : 'Buy now', 'smartpay'); ?>
+            <?php esc_html_e($label ? : 'Buy now', 'smartpay'); ?>
         </button>
     </div>
 </div>

--- a/resources/views/shortcodes/shared/form_details.php
+++ b/resources/views/shortcodes/shared/form_details.php
@@ -3,7 +3,7 @@
         <div class="card form bg-transparent border-0">
             <div class="card-body smartpay_form_builder_wrapper">
 				<?php do_action( 'before_smartpay_payment_form', $form ); ?>
-                <form id="smartpay-payment-form" action="<?php echo smartpay_get_payment_page_uri(); ?>" method="POST"
+                <form id="smartpay-payment-form" action="<?php echo esc_url(smartpay_get_payment_page_uri()); ?>" method="POST"
                       enctype="multipart/form-data">
                     <div id="form-response" class="mb-3"></div>
 					<?php wp_nonce_field( 'smartpay_process_payment', 'smartpay_process_payment' ); ?>
@@ -12,7 +12,7 @@
                     <div id="mobile-field"></div>
 
                     <div class="form--amount-section mb-3">
-                        <label class="form-amounts--label d-block m-0 mb-2"><?php _e( 'Select an amount', 'smartpay' ) ?></label>
+                        <label class="form-amounts--label d-block m-0 mb-2"><?php esc_html_e( 'Select an amount', 'smartpay' ) ?></label>
                         <div class="form-amounts">
                             <div class="form-plan-grid ">
 								<?php foreach ( $form->amounts as $index => $amount ) : ?>
@@ -21,16 +21,16 @@
 									<?php if ( $billingType == \SmartPay\Models\Payment::BILLING_TYPE_ONE_TIME ): ?>
                                         <label class="form-plan-card plan-amount <?php echo 0 === $index ? 'selected' : '' ?>">
                                             <input type="radio" name="_form_amount" id="_form_amount_<?php echo
-											$amount['key']; ?>" class="radio" value="<?php echo
-											$amount['amount']; ?>" <?php echo 0 === $index ? 'checked' : '' ?> />
+											esc_attr($amount['key']); ?>" class="radio" value="<?php echo
+											esc_attr($amount['amount']); ?>" <?php echo 0 === $index ? 'checked' : '' ?> />
                                             <span class="plan-details" aria-hidden="true">
                                         <span class="plan-type">
-                                            <?php echo $amount['label'] ? $amount['label'] : ''; ?>
+                                            <?php echo esc_html($amount['label'] ? $amount['label'] : ''); ?>
                                         </span>
                                         <span class="plan-cost">
-                                            <?php echo smartpay_amount_format( $amount['amount'] ); ?>
+                                            <?php echo esc_html(smartpay_amount_format( $amount['amount'] )); ?>
                                         </span>
-                                                <input type="hidden" name="_form_billing_type" id="_form_billing_type_<?php echo $amount['key']; ?>" value="<?php echo $billingType; ?>">
+                                                <input type="hidden" name="_form_billing_type" id="_form_billing_type_<?php echo esc_attr($amount['key']); ?>" value="<?php echo esc_attr($billingType); ?>">
                                         </label>
 									<?php endif; ?>
 
@@ -38,32 +38,32 @@
 
                                         <label class="form-plan-card plan-amount <?php echo 0 === $index ? 'selected' : '' ?>">
                                             <input type="hidden" name="_form_amount_key"
-                                                   value="<?php echo $amount['key'] ?? ''; ?>">
+                                                   value="<?php echo esc_attr($amount['key'] ?? ''); ?>">
                                             <input type="radio" name="_form_amount" id="_form_amount_<?php echo
-											$amount['key']; ?><?php echo
-											$amount['key']; ?>" class="radio" value="<?php echo
-											$amount['amount']; ?>" <?php echo 0 === $index ? 'checked' : '' ?> />
+											esc_attr($amount['key']); ?><?php echo
+											esc_attr($amount['key']); ?>" class="radio" value="<?php echo
+											esc_attr($amount['amount']); ?>" <?php echo 0 === $index ? 'checked' : '' ?> />
                                             <span class="plan-details" aria-hidden="true">
                                         <span class="plan-type">
-                                            <?php echo $amount['label'] ? $amount['label'] : ''; ?>
+                                            <?php echo esc_html($amount['label'] ? $amount['label'] : ''); ?>
                                         </span>
                                         <span class="plan-cost">
-                                            <?php echo smartpay_amount_format( $amount['amount'] ); ?>
+                                            <?php echo esc_html(smartpay_amount_format( $amount['amount'] )); ?>
                                             <span class="slash">/</span>
-                                            <span class="plan-cycle"><?php echo $amount['billing_period']; ?></span></span>
+                                            <span class="plan-cycle"><?php echo esc_html($amount['billing_period']); ?></span></span>
                                             <?php if ( isset( $amount['total_billing_cycle'] ) && $amount['total_billing_cycle'] > 0 ): ?>
-                                                <span class="plan-additional-info">Billed <?php echo $amount['total_billing_cycle']; ?> times</span>
+                                                <span class="plan-additional-info">Billed <?php echo esc_html($amount['total_billing_cycle']); ?> times</span>
                                             <?php endif; ?>
 
 												<?php if ( isset( $amount['additional_charge'] ) && $amount['additional_charge'] > 0 ): ?>
-                                                    <span class="plan-additional-info"> Additional Charge <?php echo $amount['additional_charge'] . smartpay_get_currency_symbol(); ?></span>
+                                                    <span class="plan-additional-info"> Additional Charge <?php echo esc_html($amount['additional_charge'] . smartpay_get_currency_symbol()); ?></span>
 												<?php endif; ?>
                                         </span>
-                                            <input type="hidden" name="_form_billing_type" id="_form_billing_type_<?php echo $amount['key']; ?>" value="<?php echo $billingType; ?>">
+                                            <input type="hidden" name="_form_billing_type" id="_form_billing_type_<?php echo esc_attr($amount['key']); ?>" value="<?php echo esc_attr($billingType); ?>">
 
                                             <input type="hidden" name="_form_billing_period"
-                                                   id="_form_billing_period_<?php echo $amount['key']; ?>"
-                                                   value="<?php echo $amount['billing_period']; ?>">
+                                                   id="_form_billing_period_<?php echo esc_attr($amount['key']); ?>"
+                                                   value="<?php echo esc_attr($amount['billing_period']); ?>">
                                         </label>
 									<?php endif; ?>
 								<?php endforeach; ?>
@@ -74,38 +74,38 @@
 							$defaultAmount = reset( $formAmounts );
 							?>
                             <input type="hidden" name="smartpay_form_billing_type"
-                                   value="<?php echo $defaultAmount['billing_type'] ?? \SmartPay\Models\Payment::BILLING_TYPE_ONE_TIME ?>">
+                                   value="<?php echo esc_attr($defaultAmount['billing_type'] ?? \SmartPay\Models\Payment::BILLING_TYPE_ONE_TIME) ?>">
                             <input type="hidden" name="smartpay_form_billing_period"
-                                   value="<?php echo $defaultAmount['billing_period'] ?? \SmartPay\Models\Payment::BILLING_PERIOD_MONTHLY ?>">
+                                   value="<?php echo esc_attr($defaultAmount['billing_period'] ?? \SmartPay\Models\Payment::BILLING_PERIOD_MONTHLY) ?>">
 
 							<?php if ( $form->settings['allowCustomAmount'] ) : ?>
                                 <!-- // Allow custom payment -->
                                 <div class="form-group custom-amount-wrapper m-0 ">
                                     <label for="smartpay_custom_amount" class="form-amounts--label d-block m-0 mb-2">
-										<?php echo $form->settings['customAmountLabel']; ?></label>
+										<?php echo esc_html($form->settings['customAmountLabel']); ?></label>
                                     <div class="input-group mb-3">
                                         <div class="input-group-prepend">
                                             <span class="input-group-text px-3"
-                                                  id="default-currency"><?php echo smartpay_get_currency_symbol() ?></span>
+                                                  id="default-currency"><?php echo esc_html(smartpay_get_currency_symbol()) ?></span>
                                         </div>
                                         <input type="text" class="form-control form--custom-amount amount"
                                                id="smartpay_custom_amount" name="smartpay_form_amount"
-                                               value="<?php echo $defaultAmount['amount'] ?>" placeholder="">
+                                               value="<?php echo esc_attr($defaultAmount['amount']) ?>" placeholder="">
                                     </div>
                                 </div>
 							<?php else : ?>
 								<?php $formAmounts = $form->amounts; ?>
                                 <input type="hidden" class="form-control form--custom-amount amount"
-                                       name="smartpay_form_amount" value="<?php echo $defaultAmount['amount'] ?>">
+                                       name="smartpay_form_amount" value="<?php echo esc_attr($defaultAmount['amount']) ?>">
 							<?php endif; ?>
                         </div>
                     </div>
 
                     <input type="hidden" name="smartpay_selected_amount_key"
-                           value="<?php echo $form->amounts[0]['key'] ?? '' ?>">
+                           value="<?php echo esc_attr($form->amounts[0]['key'] ?? '') ?>">
 
                     <input type="hidden" name="smartpay_form_id" id="smartpay_form_id"
-                           value="<?php echo $form->id ?? 0; ?>">
+                           value="<?php echo esc_attr($form->id ?? 0); ?>">
 
                     <input type="hidden" name="smartpay_is_custom_payment" id="smartpay_is_custom_payment" value="false">
 
@@ -117,7 +117,7 @@
 
                         <!-- // If it has multiple payment gateway -->
 					<?php elseif ( count( $gateways ) > 1 ) : ?>
-                        <label class="payment-gateway--label"><?php _e( 'Select a payment method', 'smartpay' ); ?></label>
+                        <label class="payment-gateway--label"><?php esc_html_e( 'Select a payment method', 'smartpay' ); ?></label>
                         <div class="mb-4">
 
                             <div class="gateways m-0 justify-content-left d-flex">
@@ -138,7 +138,7 @@
                         </div>
 					<?php else : ?>
 						<?php $has_payment_error = true; ?>
-                        <div class="alert alert-danger"><?php _e( 'You must enable a payment gateway to proceed a payment.', 'smartpay' ); ?></div>
+                        <div class="alert alert-danger"><?php esc_html_e( 'You must enable a payment gateway to proceed a payment.', 'smartpay' ); ?></div>
 					<?php endif; ?>
 
 					<?php do_action( 'before_smartpay_payment_form_button', $form ); ?>
@@ -146,7 +146,7 @@
                     <button type="button"
                             class="btn btn-success btn-block btn-lg smartpay-form-pay-now" <?php if ( $has_payment_error ) {
 						echo 'disabled';
-					} ?>><?php _e( $form['settings']['payButtonLabel'] ?: 'Pay Now', 'smartpay' ) ?></button>
+					} ?>><?php esc_html_e( $form['settings']['payButtonLabel'] ?: 'Pay Now', 'smartpay' ) ?></button>
 
 					<?php do_action( 'after_smartpay_payment_form_button', $form ); ?>
                 </form>

--- a/resources/views/shortcodes/shared/form_details.php
+++ b/resources/views/shortcodes/shared/form_details.php
@@ -7,7 +7,9 @@
                       enctype="multipart/form-data">
                     <div id="form-response" class="mb-3"></div>
 					<?php wp_nonce_field( 'smartpay_process_payment', 'smartpay_process_payment' ); ?>
-					<?php echo do_blocks( $form->body );
+					<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The generated output has already escaped.
+					echo do_blocks( $form->body );
 					?>
                     <div id="mobile-field"></div>
 

--- a/resources/views/shortcodes/shared/payment_modal.php
+++ b/resources/views/shortcodes/shared/payment_modal.php
@@ -25,7 +25,7 @@ $has_payment_error = false;
                     </svg>
                 </button>
                 <div class="d-flex flex-column justify-content-center modal-title">
-                    <p class="payment-modal--small-title mb-2 text-capitalize"><?php echo $product->title ?? $form->title ?? 'Product/Form'; ?></p>
+                    <p class="payment-modal--small-title mb-2 text-capitalize"><?php echo esc_html($product->title ?? $form->title ?? 'Product/Form'); ?></p>
                     <h2 class="payment-modal--title amount m-0">--</h2>
                 </div>
 
@@ -44,7 +44,7 @@ $has_payment_error = false;
 
             <div class="modal-body p-1 text-center step-1">
                 <div class="align-self-center w-100">
-                    <form action="<?php echo smartpay_get_payment_page_uri(); ?>" method="POST">
+                    <form action="<?php echo esc_url(smartpay_get_payment_page_uri()); ?>" method="POST">
                         <?php wp_nonce_field('smartpay_process_payment', 'smartpay_process_payment'); ?>
                         <div class="payment-modal--gateway">
                             <!-- // If Product has Zero sale amount -->
@@ -58,7 +58,7 @@ $has_payment_error = false;
                             <?php elseif (count($gateways) == 1) : ?>
                                 <?php $gateways_index = array_keys($gateways); ?>
                                 <p class="payment-gateway--label text-muted single-gateway">
-                                    <?php echo sprintf(__('Payment method - ', 'smartpay') . ' <strong>%s</strong>', esc_html(reset($gateways)['checkout_label']));
+                                    <?php echo wp_kses_post(sprintf(__('Payment method - ', 'smartpay') . ' <strong>%s</strong>', esc_html(reset($gateways)['checkout_label'])));
                                     ?>
                                 </p>
                                 <input class="d-none" type="radio" name="smartpay_gateway" id="smartpay_gateway" value="<?php echo esc_html(reset($gateways_index)); ?>" checked>
@@ -79,28 +79,28 @@ $has_payment_error = false;
                                 </div>
                             <?php else : ?>
                                 <?php $has_payment_error = true; ?>
-                                <div class="alert alert-danger"><?php echo __('You must enable a payment gateway to proceed a payment.', 'smartpay'); ?></div>
+                                <div class="alert alert-danger"><?php echo esc_html( __('You must enable a payment gateway to proceed a payment.', 'smartpay')); ?></div>
                             <?php endif; ?>
                         </div>
 
                         <div class="payment-modal--user-info">
                             <div class="form-row">
                                 <div class="col-sm-6 form-group">
-                                    <input type="text" placeholder="First name" class="form-control" name="smartpay_first_name" id="smartpay_first_name" value="<?php echo $customer->first_name ?? ''; ?>" autocomplete="first_name" required>
+                                    <input type="text" placeholder="First name" class="form-control" name="smartpay_first_name" id="smartpay_first_name" value="<?php echo esc_attr($customer->first_name ?? ''); ?>" autocomplete="first_name" required>
                                 </div>
                                 <div class="col-sm-6 form-group">
-                                    <input type="text" placeholder="Last name" class="form-control" name="smartpay_last_name" id="smartpay_last_name" value="<?php echo $customer->last_name ?? ''; ?>" autocomplete="last_name" required>
+                                    <input type="text" placeholder="Last name" class="form-control" name="smartpay_last_name" id="smartpay_last_name" value="<?php echo esc_attr($customer->last_name ?? ''); ?>" autocomplete="last_name" required>
                                 </div>
                             </div>
                             <div class="form-group">
-                                <input type="email" placeholder="Email address" class="form-control" name="smartpay_email" id="smartpay_email" value="<?php echo $customer->email ?? ''; ?>" autocomplete="email" required>
+                                <input type="email" placeholder="Email address" class="form-control" name="smartpay_email" id="smartpay_email" value="<?php echo esc_attr($customer->email ?? ''); ?>" autocomplete="email" required>
                             </div>
                             <div id="mobile-field"></div>
 
                             <?php do_action('smartpay_before_product_payment_form_button', $product); ?>
 
                             <button type="button" class="btn btn-success btn-block btn-lg smartpay-pay-now" <?php if ($has_payment_error) echo 'disabled'; ?>>
-                                <?php echo __('Pay Now', 'smartpay'); ?>
+                                <?php echo esc_html__('Pay Now', 'smartpay'); ?>
                             </button>
 
                             <?php do_action('smartpay_after_product_payment_form_button', $product); ?>
@@ -114,12 +114,12 @@ $has_payment_error = false;
                 <div class="align-self-center">
                     <div class="mb-5">
                         <div class="alert alert-warning py-3">
-                            <p class="m-0"><?php echo __('Don\'t close this window before completing payment!', 'smartpay'); ?></p>
+                            <p class="m-0"><?php echo esc_html__('Don\'t close this window before completing payment!', 'smartpay'); ?></p>
                         </div>
                     </div>
                     <div class="dynamic-content">
                         <div class="spinner-border" style="width: 40px; height: 40px;">
-                            <span class="sr-only"><?php echo __('Loading'); ?>...</span>
+                            <span class="sr-only"><?php echo esc_html__('Loading'); ?>...</span>
                         </div>
                     </div>
                 </div>
@@ -127,7 +127,7 @@ $has_payment_error = false;
 
             <div class="modal-loading justify-content-center align-items-center">
                 <div class="spinner-border text-secondary" style="width: 40px; height: 40px;">
-                    <span class="sr-only"><?php echo __('Loading'); ?>...</span>
+                    <span class="sr-only"><?php echo esc_html__('Loading', 'smartpay'); ?>...</span>
                 </div>
             </div>
         </div>

--- a/resources/views/shortcodes/shared/payment_modal.php
+++ b/resources/views/shortcodes/shared/payment_modal.php
@@ -61,7 +61,7 @@ $has_payment_error = false;
                                     <?php echo wp_kses_post(sprintf(__('Payment method - ', 'smartpay') . ' <strong>%s</strong>', esc_html(reset($gateways)['checkout_label'])));
                                     ?>
                                 </p>
-                                <input class="d-none" type="radio" name="smartpay_gateway" id="smartpay_gateway" value="<?php echo esc_html(reset($gateways_index)); ?>" checked>
+                                <input class="d-none" type="radio" name="smartpay_gateway" id="smartpay_gateway" value="<?php echo esc_attr(reset($gateways_index)); ?>" checked>
 
                                 <!-- // If it has multiple payment gateway -->
                             <?php elseif (count($gateways) > 1) : ?>
@@ -71,7 +71,7 @@ $has_payment_error = false;
                                             <input type="radio" class="d-none" name="smartpay_gateway" id="<?php echo 'smartpay_gateway_' . esc_attr($gatewayId); ?>" value="<?php echo esc_attr($gatewayId) ?>" <?php echo checked($gatewayId, $chosen_gateway, false); ?>>
                                             <label for="<?php echo 'smartpay_gateway_' . esc_attr($gatewayId); ?>" class="gateway--label">
                                                 <!-- dynamically load the gateway image -->
-                                                <img src="<?php echo esc_html($gateway['gateway_icon']); ?>" alt="<?php echo esc_html($gateway['checkout_label']); ?>">
+                                                <img src="<?php echo esc_url($gateway['gateway_icon']); ?>" alt="<?php echo esc_attr($gateway['checkout_label']); ?>">
                                                 <!-- <?php echo esc_html($gateway['checkout_label']); ?> -->
                                             </label>
                                         </div>
@@ -79,7 +79,7 @@ $has_payment_error = false;
                                 </div>
                             <?php else : ?>
                                 <?php $has_payment_error = true; ?>
-                                <div class="alert alert-danger"><?php echo esc_html( __('You must enable a payment gateway to proceed a payment.', 'smartpay')); ?></div>
+                                <div class="alert alert-danger"><?php echo esc_html__('You must enable a payment gateway to proceed a payment.', 'smartpay'); ?></div>
                             <?php endif; ?>
                         </div>
 
@@ -135,4 +135,3 @@ $has_payment_error = false;
 </div>
 
 <!--<div id="smartpay_currency_symbol" data-value="$"></div>-->
-

--- a/resources/views/shortcodes/shared/product_details.php
+++ b/resources/views/shortcodes/shared/product_details.php
@@ -4,7 +4,7 @@
         <div class="card product">
             <?php if (count($product->covers)) : ?>
                 <div class="bg-light product--image border-bottom">
-                    <img src="<?php echo $product->covers[0]['url']; ?>" class="card-img-top">
+                    <img src="<?php echo esc_url($product->covers[0]['url']); ?>" class="card-img-top">
                 </div>
             <?php endif; ?>
 
@@ -12,12 +12,12 @@
                 <div class="row">
                     <div class="col-sm-12 col-md-7 mb-3">
                         <?php if ($product->title) : ?>
-                            <h2 class="card-title product--title mt-0 mb-2"><?php echo $product->title; ?></h2>
+                            <h2 class="card-title product--title mt-0 mb-2"><?php echo esc_html($product->title); ?></h2>
                         <?php endif; ?>
 
                         <?php if ($product->description) : ?>
                             <div class="card-text product--description">
-                                <?php echo wpautop($product->description); ?>
+                                <?php echo wp_kses_post(wpautop($product->description)); ?>
                             </div>
                         <?php endif; ?>
                     </div>
@@ -35,21 +35,21 @@
                                             <?php $billingPeriod = $variation->extra['billing_period'] ?? \SmartPay\Models\Payment::BILLING_PERIOD_MONTHLY; ?>
                                             <li class="list-group-item variation price <?php echo 0 == $index ? 'selected' : ''; ?>">
                                                 <input type="hidden" name="_product_additional_charge"
-                                                       value="<?php echo $variation->extra['additional_charge'] ?? 0 ?>">
-                                                <label for="<?php echo "product_variation_{$variation->id}"; ?>" class="d-block m-0">
-                                                    <input type="hidden" name="_smartpay_product_id" id="<?php echo "product_variation_{$variation->id}"; ?>" value="<?php echo esc_attr($variation->id); ?>" <?php echo 0 == $index ? 'checked' : ''; ?>>
-                                                    <input type="hidden" name="_product_billing_type" id="_product_billing_type_<?php echo $variation->id; ?>" value="<?php echo $billingType; ?>">
+                                                       value="<?php echo esc_attr($variation->extra['additional_charge'] ?? 0) ?>">
+                                                <label for="<?php echo esc_attr("product_variation_{$variation->id}"); ?>" class="d-block m-0">
+                                                    <input type="hidden" name="_smartpay_product_id" id="<?php echo esc_attr("product_variation_{$variation->id}"); ?>" value="<?php echo esc_attr($variation->id); ?>" <?php echo 0 == $index ? 'checked' : ''; ?>>
+                                                    <input type="hidden" name="_product_billing_type" id="_product_billing_type_<?php echo esc_attr($variation->id); ?>" value="<?php echo esc_attr($billingType); ?>">
                                                     <?php if (\SmartPay\Models\Payment::BILLING_TYPE_SUBSCRIPTION === $billingType) : ?>
-                                                        <input type="hidden" name="_product_billing_period" id="_product_billing_period_<?php echo $variation->id; ?>" value="<?php echo $billingPeriod; ?>">
+                                                        <input type="hidden" name="_product_billing_period" id="_product_billing_period_<?php echo esc_attr($variation->id); ?>" value="<?php echo esc_attr($billingPeriod); ?>">
                                                     <?php endif; ?>
                                                     <div class="price--amount">
-                                                        <span class="sale-price" data-price="<?php echo $variation->sale_price; ?>"><?php echo
-                                                            smartpay_amount_format(($variation->price)); ?></span>
+                                                        <span class="sale-price" data-price="<?php echo esc_attr($variation->sale_price); ?>"><?php echo
+                                                            esc_html(smartpay_amount_format(($variation->price))); ?></span>
                                                         <?php if ($variation->sale_price && ($variation->base_price > $variation->sale_price)) : ?>
-                                                            <del class="base-price"><?php echo smartpay_amount_format($variation->base_price); ?></del>
+                                                            <del class="base-price"><?php echo esc_html(smartpay_amount_format($variation->base_price)); ?></del>
                                                         <?php endif; ?>
                                                         <?php if (\SmartPay\Models\Payment::BILLING_TYPE_SUBSCRIPTION === $billingType) : ?>
-                                                            <span>/ <?php echo __($billingPeriod, 'smartpay'); ?></span>
+                                                            <span>/ <?php echo esc_html__($billingPeriod, 'smartpay'); ?></span>
                                                         <?php endif; ?>
                                                     </div>
                                                     <h5 class="m-0 price--title">
@@ -57,7 +57,7 @@
                                                     </h5>
                                                     <?php if ($variation->description ?? false) : ?>
                                                         <p class="variation--description m-0">
-                                                            <?php echo wpautop($variation->description); ?>
+                                                            <?php echo wp_kses_post(wpautop($variation->description)); ?>
                                                         </p>
                                                     <?php endif; ?>
                                                 </label>
@@ -72,22 +72,22 @@
                                             <label class="d-block m-0">
                                                 <div class="price--amount">
                                                     <?php if ($product->sale_price <= 0) : ?>
-                                                        <span class="sale-price"><?php echo __('Free', 'smartpay'); ?></span>
+                                                        <span class="sale-price"><?php echo esc_html__('Free', 'smartpay'); ?></span>
                                                         <?php if ($product->base_price > $product->sale_price) : ?>
-                                                            <del class="base-price"><?php echo smartpay_amount_format($product->base_price); ?></del>
+                                                            <del class="base-price"><?php echo esc_html(smartpay_amount_format($product->base_price)); ?></del>
                                                         <?php endif; ?>
                                                     <?php else : ?>
-                                                        <span class="sale-price"><?php echo smartpay_amount_format($product->sale_price); ?></span>
+                                                        <span class="sale-price"><?php echo esc_html(smartpay_amount_format($product->sale_price)); ?></span>
                                                         <?php if ($product->sale_price && ($product->base_price > $product->sale_price)) : ?>
-                                                            <del class="base-price"><?php echo smartpay_amount_format($product->base_price); ?></del>
+                                                            <del class="base-price"><?php echo esc_html(smartpay_amount_format($product->base_price)); ?></del>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                     <?php if (\SmartPay\Models\Payment::BILLING_TYPE_SUBSCRIPTION === $productBillingType) : ?>
-                                                        <span>/ <?php echo __($productBillingPeriod, 'smartpay'); ?></span>
+                                                        <span>/ <?php echo esc_html__($productBillingPeriod, 'smartpay'); ?></span>
                                                     <?php endif; ?>
                                                 </div>
                                                 <h5 class="m-0 price--title">
-                                                    <?php echo __('Product Price', 'smartpay'); ?>
+                                                    <?php echo esc_html__('Product Price', 'smartpay'); ?>
                                                 </h5>
                                             </label>
                                         </li>
@@ -96,7 +96,7 @@
                             </div>
 
                             <button type="button" class="btn btn-success btn-block btn-lg open-payment-form">
-                                <?php echo __($product['settings']['payButtonLabel'] ?: 'Get it now', 'smartpay'); ?>
+                                <?php echo esc_html__($product['settings']['payButtonLabel'] ?: 'Get it now', 'smartpay'); ?>
                             </button>
                         </div>
                     </div>
@@ -114,12 +114,12 @@
         <!-- Form Data -->
         <input type="hidden" name="smartpay_payment_type" id="smartpay_payment_type" value="product_purchase">
         <input type="hidden" name="smartpay_product_id" value="<?php echo esc_attr($defaultVariation->id); ?>">
-        <input type="hidden" name="smartpay_product_price" value="<?php echo $defaultVariation->sale_price ?? 0; ?>">
-        <input type="hidden" name="smartpay_product_billing_type" value="<?php echo $defaultVariation->extra['billing_type'] ?? \SmartPay\Models\Payment::BILLING_TYPE_ONE_TIME; ?>">
-        <input type="hidden" name="smartpay_product_billing_period" value="<?php echo $defaultVariation->extra['billing_period'] ?? \SmartPay\Models\Payment::BILLING_PERIOD_MONTHLY; ?>">
+        <input type="hidden" name="smartpay_product_price" value="<?php echo esc_attr($defaultVariation->sale_price ?? 0); ?>">
+        <input type="hidden" name="smartpay_product_billing_type" value="<?php echo esc_attr($defaultVariation->extra['billing_type'] ?? \SmartPay\Models\Payment::BILLING_TYPE_ONE_TIME); ?>">
+        <input type="hidden" name="smartpay_product_billing_period" value="<?php echo esc_attr($defaultVariation->extra['billing_period'] ?? \SmartPay\Models\Payment::BILLING_PERIOD_MONTHLY); ?>">
 
-        <input type="hidden" name="smartpay_product_additional_charge" value="<?php echo $defaultVariation->extra['additional_charge'] ?? 0; ?>">
-        <input type="hidden" name="smartpay_selected_currency_symbol" value="<?php echo smartpay_get_currency_symbol(); ?>">
+        <input type="hidden" name="smartpay_product_additional_charge" value="<?php echo esc_attr($defaultVariation->extra['additional_charge'] ?? 0); ?>">
+        <input type="hidden" name="smartpay_selected_currency_symbol" value="<?php echo esc_attr(smartpay_get_currency_symbol()); ?>">
         <!-- /Form Data -->
 
         <!-- Payment modal -->


### PR DESCRIPTION
resolves #163 

This PR solves `errors` and `warnings` comes from `Plugin Checker`. Following categories problem is solved
- Security ✅ ( **1** remains its not from our end - attach screenshot)
- Performance ✅ 
- Accessibility ✅ 

### Special Notes (easy to review)
**Maximum error related to escaping the output. warning related to `custom db table and query` Fixing way shows below -**
- `text` are escaped by `esc_html()` or `esc_html__()` - depending on situation
- `arrtibute` are escaped by `esc_attr()` or `esc_attr__()` depending on situation like `placeholder`
- `url` are escaped by `esc_url()`
- In somewhere unharmful tags like `<p> <strong>` etc. used they are escaped by `wp_kses_post()`
- In some places, manually divided the part and `escape separately`
- After ensuring every value has escaped properly, then error remaining `echo view files` - then comment out and tell `phpcs to ignore` - I'm sure I escaped properly.

## Dependency
@aushamim cc @shamsbd71 

## Screenshots
<img width="448" height="116" alt="image" src="https://github.com/user-attachments/assets/2a681d7f-ba0c-42e1-a107-54455fbab1e1" />

<img width="1544" height="348" alt="image" src="https://github.com/user-attachments/assets/7e55f10a-ed65-4ba1-89f3-b9904b192e14" />
