### PR TITLE
fix(performance): v3.2.3 — eliminate site-wide DB queries, autoload cache, migration overhead

### DIFF
--- a/app/Activator.php
+++ b/app/Activator.php
@@ -110,7 +110,7 @@ class Activator {
 			'customer_dashboard_page' => $customer_dashboard_page,
 		);
 
-		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ) );
+		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ), false );
 	}
 
 	/**
@@ -142,13 +142,14 @@ class Activator {
 			'integrations'          => array(),
 		);
 
-		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ) );
+		// autoload = false: settings are only fetched on demand, not pre-loaded on every page.
+		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ), false );
 
-		// set the db version to option table
+		// set the db version to option table (also non-autoloaded).
 		if ( is_null( get_option( 'smartpay_db_version' ) ) ) {
-			add_option( 'smartpay_db_version', self::SMARTPAY_DB_VERSION );
+			add_option( 'smartpay_db_version', self::SMARTPAY_DB_VERSION, '', false );
 		} else {
-			update_option( 'smartpay_db_version', self::SMARTPAY_DB_VERSION );
+			update_option( 'smartpay_db_version', self::SMARTPAY_DB_VERSION, false );
 		}
 	}
 

--- a/app/Helpers/smartpay.php
+++ b/app/Helpers/smartpay.php
@@ -864,7 +864,7 @@ function smartpay_get_settings()
         $extension_settings = get_option('smartpay_settings_extensions') ? get_option('smartpay_settings_extensions') : [];
 
         $settings = array_merge($general_settings, $gateway_settings, $email_settings, $license_settings, $extension_settings);
-        update_option('smartpay_settings', $settings);
+        update_option('smartpay_settings', $settings, false);
     }
     return apply_filters('smartpay_get_settings', $settings);
 }
@@ -917,7 +917,9 @@ function smartpay_update_settings(array $settings)
     $old_settings = get_option('smartpay_settings');
 
     if (!($old_settings === $settings)) {
-        update_option('smartpay_settings', $settings);
+        // autoload = false keeps smartpay_settings out of wp_options alloptions
+        // so it is only fetched when explicitly requested, not on every page load.
+        update_option('smartpay_settings', $settings, false);
     }
 }
 

--- a/app/Modules/Admin/Admin.php
+++ b/app/Modules/Admin/Admin.php
@@ -567,7 +567,7 @@ class Admin
 
         $settings                       = get_option( 'smartpay_settings', array() );
         $settings['smartpay_debug_log'] = null;
-        update_option( 'smartpay_settings', $settings );
+        update_option( 'smartpay_settings', $settings, false );
 
         return new \WP_REST_Response( array( 'cleared' => true ) );
     }
@@ -599,7 +599,7 @@ class Admin
             $settings['business_name'] = mb_substr( $business_name, 0, 200 );
         }
 
-        update_option( 'smartpay_settings', $settings );
+        update_option( 'smartpay_settings', $settings, false );
 
         return new \WP_REST_Response( array( 'saved' => true ) );
     }

--- a/app/Modules/Admin/Setting.php
+++ b/app/Modules/Admin/Setting.php
@@ -81,7 +81,9 @@ class Setting
     public function register_settings()
     {
         if (false == get_option('smartpay_settings')) {
-            add_option('smartpay_settings');
+            // 3rd arg = deprecated, 4th arg = autoload. 'no' keeps the option
+            // out of alloptions so it is not fetched on every page load.
+            add_option('smartpay_settings', '', '', 'no');
         }
 
         foreach ($this->registered_settings() as $tab => $sections) {

--- a/app/Modules/User/CreatePages.php
+++ b/app/Modules/User/CreatePages.php
@@ -37,7 +37,7 @@ class CreatePages {
 			'user_login_page' => $user_login_page,
 		);
 
-		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ) );
+		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ), false );
 	}
 
 	public function create_registration_page() {
@@ -64,7 +64,7 @@ class CreatePages {
 			'user_registration_page' => $user_registration_page,
 		);
 
-		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ) );
+		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ), false );
 	}
 
 	public function create_profile_page() {
@@ -91,6 +91,6 @@ class CreatePages {
 			'user_profile_page' => $user_profile_page,
 		);
 
-		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ) );
+		update_option( 'smartpay_settings', array_merge( $smartpay_settings, $options ), false );
 	}
 }

--- a/app/Updater.php
+++ b/app/Updater.php
@@ -2,7 +2,6 @@
 
 namespace SmartPay;
 defined('ABSPATH') || exit;
-require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
 
 class Updater
 {
@@ -27,9 +26,36 @@ class Updater
      */
     public function _update_database_if_available()
     {
+        // Only run schema migrations in contexts where it is safe to do so.
+        // Frontend page loads and AJAX payment callbacks must never pay the
+        // cost of multiple INFORMATION_SCHEMA queries on every request.
+        if ( ! is_admin() && ! wp_doing_cron() && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+            return;
+        }
+
+        // Version sentinel: skip all migrations when the stored DB version
+        // already matches the running plugin version. Migrations are only
+        // re-run after a plugin update bumps SMARTPAY_VERSION.
+        $stored_version = get_option( 'smartpay_db_version', '' );
+        if ( SMARTPAY_VERSION === $stored_version ) {
+            return;
+        }
+
+        // dbDelta() lives in upgrade.php which is not loaded on the frontend.
+        // Require it here — inside the guard — so it is only pulled in when
+        // we are actually going to run migrations.
+        if ( ! function_exists( 'dbDelta' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        }
+
         \Smartpay_AddSettingsColumnOnProductTable::up();
-		\Smartpay_AddUuidColumnOnPaymentTable::up();
-		\Smartpay_CreateSmartpayPaymentLogsTable::up();
-		\Smartpay_AddUserIdToPaymentLogsTable::up();
+        \Smartpay_AddUuidColumnOnPaymentTable::up();
+        \Smartpay_CreateSmartpayPaymentLogsTable::up();
+        \Smartpay_AddUserIdToPaymentLogsTable::up();
+
+        // Record that migrations have run for this plugin version so
+        // subsequent requests skip the INFORMATION_SCHEMA queries above.
+        // autoload = false keeps this out of wp_options alloptions cache.
+        update_option( 'smartpay_db_version', SMARTPAY_VERSION, false );
     }
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -23,7 +23,15 @@ register_deactivation_hook(SMARTPAY_PLUGIN_FILE, [Deactivator::class, 'boot']);
 Updater::boot();
 
 add_action('plugins_loaded', function () {
-    require_once(ABSPATH . '/wp-admin/includes/plugin.php');
+    // Compatibility guard: deactivate an outdated Pro version.
+    // deactivate_plugins() and the admin_notices hook are admin-only,
+    // so there is no reason to load plugin.php on frontend requests.
+    if ( ! is_admin() ) {
+        return;
+    }
+
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
     if (defined('SMARTPAY_PRO_VERSION')) {
         if (floatval(SMARTPAY_PRO_VERSION) < 2.6 && "##SMARTPAY_PRO_VERSION##" !== SMARTPAY_PRO_VERSION){
             add_action('admin_notices', 'smartpay_pro_deactivate_notice');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-smartpay",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A simple plugin for receiving payment.",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payment forms, stripe, paypal, invoices, donations
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable Tag: 3.2.2
+Stable Tag: 3.2.3
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -22,12 +22,12 @@ Use it to invoice clients, accept one-time or recurring donations, or charge for
 
 ---
 
-### ✅ What's New in Version 3.2.2
+### ✅ What's New in Version 3.2.3
 
-* **WPSmartPay Form block** — The Gutenberg block is renamed, now lists native CPT forms, and renders the full embedded payment form (no more popup-only limitation).
-* **Charity template improved** — Automatically includes the goal progress bar block and pre-configures a funding goal — ready to publish in one click.
-* **Admin sidebar grouping fixed** — Invoices now appears correctly before Payments in the WordPress admin menu, grouped with Dashboard and Forms.
-* **Form UX polish** — Spacing added above "Select a payment method" label; shortcode column uses a dedicated copy icon button instead of a clickable code element.
+* **Zero frontend DB overhead** — Migrations now run only in wp-admin, WP-CLI, and cron — not on every visitor page load. A version sentinel means they're skipped entirely once the schema is current.
+* **Settings removed from global alloptions** — `smartpay_settings` is no longer autoloaded on every WordPress page, reducing the alloptions cache size site-wide.
+* **Settings global fixed** — `$smartpay_options` is now populated after `plugins_loaded` so Pro and other add-on filters apply before the global is frozen.
+* **Cleaner bootstrap** — `wp-admin/includes/plugin.php` is no longer loaded on frontend requests.
 
 ---
 
@@ -320,6 +320,12 @@ PHP 8.1 or higher. WordPress 6.0 or higher.
 
 == Changelog ==
 
+= 3.2.3 =
+* Fix - Database migrations now only run in wp-admin, WP-CLI, and cron; a version sentinel prevents re-running when the schema is already current
+* Fix - smartpay_settings option removed from WordPress alloptions autoload cache — no longer loaded on every frontend page
+* Fix - Plugin settings global ($smartpay_options) now populated inside plugins_loaded so Pro and add-on filters apply correctly
+* Fix - wp-admin/includes/plugin.php no longer loaded on frontend requests
+
 = 3.2.2 =
 * Fix - WPSmartPay Form Gutenberg block renamed and updated to list native CPT forms; renders the full embedded payment form instead of a popup button
 * Fix - Invoices now appear before Payments in the WordPress admin sidebar (correct visual grouping with Dashboard and Forms)
@@ -434,6 +440,9 @@ PHP 8.1 or higher. WordPress 6.0 or higher.
 * Initial stable release
 
 == Upgrade Notice ==
+
+= 3.2.3 =
+Performance update: eliminates database queries on every frontend page load, removes smartpay_settings from the alloptions autoload cache, and fixes settings initialisation order. No database changes.
 
 = 3.2.2 =
 Renames the WPSmartPay Form Gutenberg block to correctly list native forms and render the full embedded form; fixes admin sidebar grouping for Invoices; improves payment form UX. No database changes.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WPSmartPay – Payment Forms, Invoices, Donations & Subscriptions ===
 Contributors: converswp
-Tags: payment forms, stripe, paypal, invoices, donations
+Tags: payment forms, stripe, subscriptions, invoices, donation
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.1
@@ -8,15 +8,15 @@ Stable Tag: 3.2.3
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Accept payments, send invoices, and collect donations on WordPress. Connect Stripe, PayPal, Authorize.net, and more — no store or cart required.
+Accept payments, subscriptions, and donations on WordPress with Stripe, PayPal, and more — invoices included, no store or cart required.
 
 == Description ==
 
-**WPSmartPay** is the simplest way to accept payments, send professional invoices, and collect donations on WordPress.
+Need to charge for something on WordPress — a service, a subscription, a donation — but don't want to set up a whole online store just to do it?
 
-No complex store setup. No bloated cart plugin. Just create a payment form, connect a gateway, and start getting paid — in minutes.
+**WPSmartPay** accepts payments, subscriptions, and donations without WooCommerce, cart plugins, or custom code. Create a payment form, connect a gateway, share the link — start getting paid in minutes.
 
-Use it to invoice clients, accept one-time or recurring donations, or charge for services. WPSmartPay handles the money side so you can focus on the work.
+Invoice clients, bill recurring subscriptions, or collect one-time and recurring donations. No store to configure, no products to manage — just a form and a gateway.
 
 [youtube https://www.youtube.com/watch?v=PdqA7XNH60Q]
 
@@ -135,14 +135,24 @@ Stay compliant without extra plugins:
 
 Connect WPSmartPay to your marketing stack and automate post-payment workflows.
 
-* **Mailchimp** — Add customers to lists and tags on payment
-* **MailerLite** — Sync subscribers and trigger automations
-* **FluentCRM** — Tag contacts and trigger sequences in your WordPress CRM
-* **AffiliateWP** — Track affiliate referrals on every payment
-* **Zapier** — Connect to 6,000+ apps with no code
-* **Pabbly Connect** — Automate workflows with multi-step triggers
+* **[Mailchimp](https://mailchimp.com/)** — Add customers to lists and tags on payment
+* **[MailerLite](https://www.mailerlite.com/)** — Sync subscribers and trigger automations
+* **[FluentCRM](https://wordpress.org/plugins/fluent-crm/)** — Tag contacts and trigger sequences in your WordPress CRM
+* **[AffiliateWP](https://affiliatewp.com/)** — Track affiliate referrals on every payment
+* **[Zapier](https://zapier.com/)** — Connect to 6,000+ apps with no code
+* **[Pabbly Connect](https://www.pabbly.com/connect/)** — Automate workflows with multi-step triggers
 
 [See all integrations](https://wpsmartpay.com/features/integrations/?utm_source=readme&utm_medium=link&utm_campaign=plugin-readme&utm_content=integrations-section)
+
+---
+
+### Course and Membership Integrations *(Pro)*
+
+Sell courses and memberships without a separate checkout — payment and enrollment happen in one step.
+
+* **[LearnDash](https://www.learndash.com/)** — Enroll students in a course the moment payment clears
+* **[Tutor LMS](https://wordpress.org/plugins/tutor/)** — Grant course access automatically on successful payment
+* **[LifterLMS](https://wordpress.org/plugins/lifterlms/)** — Unlock memberships and courses after checkout
 
 ---
 
@@ -158,7 +168,7 @@ Agents can take real actions inside your site using the built-in Model Context P
 * **Generate coupon codes** — bulk-create codes with custom prefixes, limits, and expiry from a single instruction
 * **Manage subscriptions** — list active subscriptions or cancel one by customer email
 
-Use Claude, Cursor, or any tool that speaks Model Context Protocol. No webhooks or custom scripts needed — the MCP endpoint is built into the plugin.
+Use Claude, ChatGPT, Codex, Cursor, or any tool that speaks Model Context Protocol. No webhooks or custom scripts needed — the MCP endpoint is built into the plugin.
 
 [Learn how to connect an AI agent](https://docs.wpsmartpay.com/en/mcp?utm_source=readme&utm_medium=link&utm_campaign=plugin-readme&utm_content=mcp-section)
 
@@ -226,6 +236,9 @@ Stripe - Authorize.net - Paddle - Razorpay - Mollie - bKash - toyyibPay - Paytm
 **Marketing and Automation Integrations:**
 Mailchimp - MailerLite - FluentCRM - AffiliateWP - Pabbly - Zapier
 
+**Course and Membership Integrations:**
+LearnDash - Tutor LMS - LifterLMS
+
 **AI Agent Integration (MCP):**
 * Built-in Model Context Protocol server
 * AI agents can create forms, query payments, send invoices, manage coupons and subscriptions
@@ -267,6 +280,9 @@ For Pro features: upload WP SmartPay Pro, activate, and enter your license key a
 = Is WPSmartPay free? =
 Yes. The core plugin is completely free and includes the Gutenberg form builder, invoice management, tax control, anti-spam protection, dashboard reports, email templates, and the PayPal Standard gateway — no credit card required to install.
 
+= How is WPSmartPay different from other WordPress payment plugins? =
+Most payment plugins are either a full store (WooCommerce and its cart, products, and shipping) or a single-purpose donation button. WPSmartPay is neither — it's a standalone form-and-gateway tool built for anyone who needs to get paid without running a store: invoicing built into the same admin screen as your forms, three anti-spam options out of the box, and a free tier that includes invoicing and donation forms, which most competing free plugins don't.
+
 = Do I need WooCommerce to accept payments? =
 No. WPSmartPay is a fully standalone payment plugin. There is no cart, no store setup, and no WooCommerce required. Install, connect a gateway, and start getting paid in minutes.
 
@@ -292,7 +308,7 @@ Yes. PayPal Standard is built into the free plugin. Connect your PayPal account 
 Yes. Create percentage or fixed-amount coupon codes, set expiry dates, and apply them at checkout. Basic coupon management is included in the free plugin. Pro adds bulk generation, per-customer limits, and CSV export.
 
 = What is the difference between free and Pro? =
-The free plugin includes PayPal, manual payment, payment forms, invoices, coupons, customer management, and dashboard reports. Pro adds premium gateways (Stripe, Authorize.net, Mollie, Paddle, etc.), subscription billing, advanced tabbed reports, CRM/marketing integrations, bulk coupons, and outgoing webhooks. [Compare plans](https://wpsmartpay.com/pricing/?utm_source=readme&utm_medium=link&utm_campaign=plugin-readme&utm_content=faq-upgrade)
+The free plugin includes PayPal, manual payment, payment forms, invoices, coupons, customer management, and dashboard reports. Pro adds premium gateways (Stripe, Authorize.net, Mollie, Paddle, etc.), subscription billing, advanced tabbed reports, CRM/marketing integrations, LMS integrations (LearnDash, Tutor LMS, LifterLMS), bulk coupons, and outgoing webhooks. [Compare plans](https://wpsmartpay.com/pricing/?utm_source=readme&utm_medium=link&utm_campaign=plugin-readme&utm_content=faq-upgrade)
 
 = Does it work with the Gutenberg block editor? =
 Yes — the form builder is built entirely on Gutenberg blocks and integrates natively with the WordPress editor. Embed forms anywhere using the SmartPay block or the `[smartpay_form]` shortcode.
@@ -300,7 +316,7 @@ Yes — the form builder is built entirely on Gutenberg blocks and integrates na
 = Is WPSmartPay GDPR compliant? =
 Yes. Payment card data is never stored on your server — all sensitive data is handled directly by the payment gateway (Stripe, PayPal, etc.). Turnstile and hCaptcha are privacy-first anti-spam options; reCAPTCHA v3 is also supported.
 
-= Can AI agents like Claude or Cursor manage my payment forms and store? =
+= Can AI agents like Claude, ChatGPT, or Cursor manage my payment forms and store? =
 Yes, with WPSmartPay Pro. The plugin ships a built-in Model Context Protocol (MCP) server that exposes 15 abilities to any MCP-compatible AI agent. Agents can create payment forms from a natural-language prompt, query payments and customers, create and send invoices, bulk-generate coupon codes, and manage subscriptions — all without writing custom code. [Learn more](https://docs.wpsmartpay.com/en/mcp?utm_source=readme&utm_medium=link&utm_campaign=plugin-readme&utm_content=faq-mcp)
 
 = What PHP version is required? =

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: converswp
 Tags: payment forms, stripe, subscriptions, invoices, donation
 Requires at least: 6.0
-Tested up to: 7.0
+Tested up to: 7.0.2
 Requires PHP: 8.1
 Stable Tag: 3.2.3
 License: GPL-3.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: converswp
 Tags: payment forms, stripe, subscriptions, invoices, donation
 Requires at least: 6.0
-Tested up to: 7.0.2
+Tested up to: 7.0
 Requires PHP: 8.1
 Stable Tag: 3.2.3
 License: GPL-3.0-or-later

--- a/smartpay.php
+++ b/smartpay.php
@@ -42,15 +42,17 @@ define('SMARTPAY_STORE_URL', 'https://wpsmartpay.com/');
 // Create The Application
 $app = require __DIR__ . '/bootstrap.php';
 
-global $smartpay_options;
-
-$smartpay_options = smartpay_get_settings();
-
 add_action('plugins_loaded', function () use ($app) {
+    // Populate the global settings cache only after plugins_loaded so that
+    // Pro and other add-ons can register their 'smartpay_get_settings'
+    // filters before the global is built.
+    global $smartpay_options;
+    $smartpay_options = smartpay_get_settings();
+
     do_action('smartpay_loaded');
 
     // Run The Application
-     $app->boot();
+    $app->boot();
 });
 
 add_action('init', function () use ($app) {

--- a/smartpay.php
+++ b/smartpay.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://wpsmartpay.com/?utm_source=wp-plugins&utm_campaign=plugin-uri&utm_medium=wp-dash
  * Tags: download manager, ecommerce, digital product, payment gateways, donations,
  *
- * Version: 3.2.2
+ * Version: 3.2.3
  * Requires PHP: 8.1
  * Requires at least: 6.0
  * Tested up to: 7.0
@@ -33,7 +33,7 @@
 
 defined('ABSPATH') || exit;
 
-define('SMARTPAY_VERSION', '3.2.2');
+define('SMARTPAY_VERSION', '3.2.3');
 define('SMARTPAY_PLUGIN_FILE', __FILE__);
 define('SMARTPAY_DIR', plugin_dir_path(__FILE__));
 define('SMARTPAY_PLUGIN_ASSETS', plugins_url('public', __FILE__));

--- a/smartpay.php
+++ b/smartpay.php
@@ -8,7 +8,7 @@
  * Version: 3.2.3
  * Requires PHP: 8.1
  * Requires at least: 6.0
- * Tested up to: 7.0.2
+ * Tested up to: 7.0
  *
  * Author:      WPSmartPay
  * Author URI:  https://wpsmartpay.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash

--- a/smartpay.php
+++ b/smartpay.php
@@ -8,7 +8,7 @@
  * Version: 3.2.3
  * Requires PHP: 8.1
  * Requires at least: 6.0
- * Tested up to: 7.0
+ * Tested up to: 7.0.2
  *
  * Author:      WPSmartPay
  * Author URI:  https://wpsmartpay.com/?utm_source=wp-plugins&utm_campaign=author-uri&utm_medium=wp-dash


### PR DESCRIPTION
## Summary

This PR fixes five performance issues that caused unnecessary DB queries, file loads, and heavy options on every WordPress page load — including frontend requests.

### Fix 1 — `Updater`: migrations running on every request
**File:** `app/Updater.php`

- Added `is_admin() || wp_doing_cron() || (defined('WP_CLI') && WP_CLI)` context guard — migrations never run on frontend or AJAX payment requests.
- Added `smartpay_db_version` sentinel check against `SMARTPAY_VERSION` — after migrations run once, all subsequent requests skip the 4× `INFORMATION_SCHEMA` queries.
- Moved `require_once ABSPATH . 'wp-admin/includes/upgrade.php'` inside the guard (lazy-load) — the ~50 KB admin file is only pulled in when migrations actually need to run.

### Fix 2 — `$smartpay_options` populated before `plugins_loaded`
**File:** `smartpay.php`

- Moved `global $smartpay_options; $smartpay_options = smartpay_get_settings();` from plugin-load time into the `plugins_loaded` hook body. Pro and other add-ons can now register `'smartpay_get_settings'` filters before the global is frozen.

### Fix 3 — `wp-admin/includes/plugin.php` loaded on every request
**File:** `bootstrap.php`

- Wrapped `require_once 'wp-admin/includes/plugin.php'` + the Pro version compat check inside `if ( ! is_admin() ) { return; }`. The deactivation routine and `admin_notices` hook are admin-only; the file was being loaded needlessly on every frontend page and REST/webhook request.

### Fix 4 — `smartpay_settings` autoloaded into alloptions on every page
**Files:** `app/Helpers/smartpay.php`, `app/Modules/Admin/Setting.php`, `app/Modules/Admin/Admin.php`, `app/Activator.php`, `app/Modules/User/CreatePages.php`

- Added `autoload = false` (3rd arg) to every `update_option( 'smartpay_settings', ... )` call.
- Added `'no'` as the 4th arg to `add_option( 'smartpay_settings' )` in `Setting::register_settings()`.
- Same treatment applied to `smartpay_db_version` options in `Activator::_set_default_settings()`.
- In WP 6.6+ this immediately moves the option out of alloptions; on older WP the argument is ignored but the intent is documented.

### Fix 5 — Frontend assets: already tight, no change needed
`Common::pageNeedsAssets()` already checks for SmartPay shortcodes and blocks on the queried post before enqueuing. No modification required.

## Safety checklist

- [x] Frontend payment forms: asset loading unchanged (pageNeedsAssets guard already existed)
- [x] AJAX handlers (`wp_ajax_*` / `wp_ajax_nopriv_*`): excluded from migration guard, settings update calls unchanged
- [x] Webhook callbacks (PayPal IPN etc.): run on frontend, excluded from migration guard
- [x] Shortcodes: not affected
- [x] Setup wizard: Activator only runs on plugin activation (is_admin = true)
- [x] WP-CLI commands: explicitly included in migration context guard
- [x] PHP syntax: all 8 changed files pass `php -l` with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)