### PR TITLE
fix(forms): restore Allow Custom Amount toggle in form editor sidebar

### DIFF
--- a/resources/js/admin/form-editor-sidebar/index.js
+++ b/resources/js/admin/form-editor-sidebar/index.js
@@ -573,8 +573,27 @@ const OptionsPanel = () => {
 				onChange={ ( val ) => updateSettings( { show_title: val } ) }
 			/>
 
-			{ /* Pay Button Label → Submit Button block · Allow Custom Amount → Pricing
-			     block · Allow External Link → removed. These now live on the blocks. */ }
+			{ /* Pay Button Label → Submit Button block · Allow External Link → removed. */ }
+
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Allow Custom Amount', 'smartpay' ) }
+				help={ __( 'Let visitors enter any amount — ideal for donations.', 'smartpay' ) }
+				checked={ !! settings.allow_custom_amount }
+				onChange={ ( val ) => updateSettings( { allow_custom_amount: val } ) }
+			/>
+
+			{ settings.allow_custom_amount && (
+				<div className="sp-sidebar-field">
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Custom Amount Label', 'smartpay' ) }
+						value={ settings.custom_amount_label || '' }
+						placeholder={ __( 'Enter custom amount', 'smartpay' ) }
+						onChange={ ( val ) => updateSettings( { custom_amount_label: val } ) }
+					/>
+				</div>
+			) }
 
 			<div className="sp-sidebar-field">
 				<SelectControl

--- a/resources/views/native-form-embed.php
+++ b/resources/views/native-form-embed.php
@@ -117,11 +117,13 @@ $GLOBALS['smartpay_payment_response_rendered'] = false;
 
 					<div id="mobile-field"></div>
 
-					<?php if ( ! empty( $amounts ) && ! $has_pricing_block ) : ?>
+					<?php if ( ! $has_pricing_block && ( ! empty( $amounts ) || $allow_custom_amount ) ) : ?>
 					<div class="form--amount-section mb-3">
+						<?php if ( ! empty( $amounts ) ) : ?>
 						<label class="form-amounts--label d-block m-0 mb-2">
 							<?php esc_html_e( 'Select an amount', 'smartpay' ); ?>
 						</label>
+						<?php endif; ?>
 						<div class="form-amounts">
 							<div class="form-plan-grid">
 								<?php foreach ( $amounts as $index => $amount ) : ?>


### PR DESCRIPTION
## Summary

- Restores the **Allow Custom Amount** toggle to the Document sidebar in the Gutenberg form editor (it was removed when the PricingField block was introduced, with a comment saying the feature moved to the block inspector — but that made it undiscoverable for most users)
- Also adds a **Custom Amount Label** text field that appears below the toggle when enabled
- Fixes **custom-amount-only / donation forms** — the PHP template previously only rendered the amount section when preset prices existed; now it also renders when `allow_custom_amount` is true, so a form with no fixed price cards still shows the free-entry input

## What changed

**`resources/js/admin/form-editor-sidebar/index.js`**
- Added `ToggleControl` for `allow_custom_amount` written to `_smartpay_settings`
- Added conditional `TextControl` for `custom_amount_label` (shown only when toggle is on)

**`resources/views/native-form-embed.php`**
- Changed outer condition from `! empty($amounts) && ! $has_pricing_block` → `! $has_pricing_block && (! empty($amounts) || $allow_custom_amount)`
- Hides the "Select an amount" label when there are no preset price cards (custom-amount-only forms)

## Test plan

- [ ] Create a new CPT form → Document sidebar should show "Allow Custom Amount" toggle
- [ ] Toggle on → "Custom Amount Label" text field appears; toggle off → it hides
- [ ] Form with preset amounts + Allow Custom Amount on → custom amount text input renders below the price cards (existing behaviour)
- [ ] Form with NO preset amounts + Allow Custom Amount on → custom amount input renders alone with no "Select an amount" label (donation-only form)
- [ ] Form with pricing block + Allow Custom Amount on in sidebar → sidebar setting is ignored; the block controls it (block's own inspector toggle takes precedence)
- [ ] Allow Custom Amount off in sidebar, no pricing block → no amount field rendered (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)